### PR TITLE
Feature/114 finish off rake task to process permanent deletions

### DIFF
--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -72,7 +72,7 @@ class Admin::ServicesController < Admin::BaseController
   end
 
   def service_params
-    params.require(:service).permit(
+    result_params = params.require(:service).permit(
       :name,
       :organisation_id,
       :description,
@@ -142,6 +142,14 @@ class Admin::ServicesController < Admin::BaseController
         accessibility_ids: []
       ]
     )
+
+    # map fields_for submitted values, which are of the form 'id => { answer: text }' into an array of '[{ id: id, answer: text }]'
+    if result_params['local_offer_attributes']&.[]('survey_answers')
+      result_params['local_offer_attributes']['survey_answers'] =
+          result_params['local_offer_attributes']['survey_answers'].to_h.map{|k,v| { id: k.to_i, answer: v['answer']}}
+    end
+
+    result_params
   end
 
 end

--- a/lib/tasks/process_permanent_deletions.rake
+++ b/lib/tasks/process_permanent_deletions.rake
@@ -1,7 +1,22 @@
 task :process_permanent_deletions => :environment  do
+    destroyed_count = 0
     Service.discarded.each do |s|
-        # TODO:
-        # 1. check if marked_for_deletion value is more than 3o days in the past
-        # 2. If so, delete service and all its snapshots and dependents
+      service_id = s.id
+      next unless s.marked_for_deletion
+      next unless s.marked_for_deletion <= DateTime.now.beginning_of_day - 30.days
+      s.snapshots.destroy_all
+      s.service_at_locations.destroy_all
+      s.service_taxonomies.destroy_all
+      s.contacts.destroy_all
+      s.local_offer&.destroy
+      s.regular_schedules.destroy_all
+      s.cost_options.destroy_all
+      s.feedbacks.destroy_all
+      s.notes.destroy_all
+      s.watches.destroy_all
+      s.destroy
+      puts "Destroyed service #{service_id} and dependents"
+      destroyed_count += 1
     end
+    puts "Destroyed #{destroyed_count} services"
 end


### PR DESCRIPTION
Resulting deletion log (filtered to deletion lines only)
```
  Snapshot Destroy (0.4ms)  DELETE FROM "snapshots" WHERE "snapshots"."id" = $1  [["id", 3745]]
  Snapshot Destroy (0.2ms)  DELETE FROM "snapshots" WHERE "snapshots"."id" = $1  [["id", 3746]]
  Snapshot Destroy (0.3ms)  DELETE FROM "snapshots" WHERE "snapshots"."id" = $1  [["id", 3747]]
  Snapshot Destroy (0.3ms)  DELETE FROM "snapshots" WHERE "snapshots"."id" = $1  [["id", 3748]]
  ServiceAtLocation Destroy (0.4ms)  DELETE FROM "service_at_locations" WHERE "service_at_locations"."id" = $1  [["id", 3587]]
  Contact Destroy (0.4ms)  DELETE FROM "contacts" WHERE "contacts"."id" = $1  [["id", 3375]]
  LocalOffer Destroy (0.5ms)  DELETE FROM "local_offers" WHERE "local_offers"."id" = $1  [["id", 5]]
  RegularSchedule Destroy (0.5ms)  DELETE FROM "regular_schedules" WHERE "regular_schedules"."id" = $1  [["id", 2]]
  CostOption Destroy (0.4ms)  DELETE FROM "cost_options" WHERE "cost_options"."id" = $1  [["id", 2]]
  Feedback Destroy (0.3ms)  DELETE FROM "feedbacks" WHERE "feedbacks"."id" = $1  [["id", 1]]
  Note Destroy (0.4ms)  DELETE FROM "notes" WHERE "notes"."id" = $1  [["id", 1]]
  Watch Destroy (0.4ms)  DELETE FROM "watches" WHERE "watches"."id" = $1  [["id", 1]]
  ActsAsTaggableOn::Tagging Destroy (0.7ms)  DELETE FROM "taggings" WHERE "taggings"."id" = $1  [["id", 2]]
  Service Destroy (1.9ms)  DELETE FROM "services" WHERE "services"."id" = $1  [["id", 3587]]
```