### PR TITLE
Feature/oauth

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'closure_tree'
 gem 'uk_postcode'
 gem 'diffy'
 gem 'mongo'
+gem 'doorkeeper'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,8 @@ GEM
     discard (1.2.0)
       activerecord (>= 4.2, < 7)
     docile (1.3.2)
+    doorkeeper (5.4.0)
+      railties (>= 5)
     dotenv (2.7.4)
     dotenv-rails (2.7.4)
       dotenv (= 2.7.4)
@@ -391,6 +393,7 @@ DEPENDENCIES
   devise_lastseenable
   diffy
   discard (~> 1.2)
+  doorkeeper
   dotenv-rails
   email_address
   factory_bot_rails

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 A [standards-driven](https://opencommunity.org.uk/) API and comprehensive set of admin tools for managing records about local community services, groups and activities.
 
-It's a rails app backed by a postgres database.
+It's a Rails app backed by a postgres database. It can also act as an OAuth provider via [Doorkeeper](https://github.com/doorkeeper-gem/doorkeeper).
 
 Outpost works alongside a [seperate API component](https://github.com/wearefuturegov/outpost-api-service/).
 
@@ -41,6 +41,14 @@ rake
 ```
 
 For the database seed to succeed, you need a source data file `bucksfis.csv` in the `lib/seeds` folder.
+
+### With Docker
+
+With [docker-compose](https://docs.docker.com/compose/) and [docker](https://www.docker.com/), after cloning the project:
+
+- Bring up the databases with `docker-compose up`
+- Populate your environment variables
+- Run the application with `rails s`
 
 ### Building the public index
 
@@ -73,13 +81,11 @@ In production only:
 - `MAILER_HOST` where the app lives on the web, to correctly form urls in emails
 - `MAILER_FROM` the email address emails will be delivered from
 
-## Running it locally
+## OAuth provider
 
-With [docker-compose](https://docs.docker.com/compose/) and [docker](https://www.docker.com/), after cloning the project:
+Outpost can work as an identity provider for other apps. Users with the highest permissions can access the `/oauth/applications` route to create credentials.
 
-- Bring up the databases with `docker-compose up`
-- Populate your environment variables
-- Run the application with `rails s`
+Once authenticated, consumer apps can fetch information about the currently logged in user with the `/api/v1/me` endpoint.
 
-## E2E test coverage
+## End-to-end test coverage
 See the readme [here](https://github.com/wearefuturegov/outpost/tree/master/features)

--- a/app/controllers/api/v1/me_controller.rb
+++ b/app/controllers/api/v1/me_controller.rb
@@ -1,0 +1,13 @@
+class API::V1::MeController < ApplicationController
+    def show
+        render json: User.find(doorkeeper_token.resource_owner_id)
+            .as_json(include: [
+                organisation: { 
+                    only: [:id, :name], 
+                    include: [
+                        services: {only: [:id, :name]}
+                    ]
+                }
+            ])
+    end
+end

--- a/app/controllers/api/v1/me_controller.rb
+++ b/app/controllers/api/v1/me_controller.rb
@@ -1,4 +1,6 @@
 class API::V1::MeController < ApplicationController
+    before_action :doorkeeper_authorize!
+    
     def show
         render json: User.find(doorkeeper_token.resource_owner_id)
             .as_json(include: [

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,6 +42,15 @@ class User < ApplicationRecord
           :lastseenable, 
           :secure_validatable
 
+  has_many :access_grants,
+          class_name: 'Doorkeeper::AccessGrant',
+          foreign_key: :resource_owner_id,
+          dependent: :delete_all # or :destroy if you need callbacks
+
+  has_many :access_tokens,
+          class_name: 'Doorkeeper::AccessToken',
+          foreign_key: :resource_owner_id,
+          dependent: :delete_all # or :destroy if you need callbacks
 
   def active_for_authentication? 
     super && kept? 

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,489 @@
+# frozen_string_literal: true
+
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use (requires ORM extensions installed).
+  # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms
+  orm :active_record
+
+  # This block will be called to check whether the resource owner is authenticated or not.
+  resource_owner_authenticator do
+    raise "Please configure doorkeeper resource_owner_authenticator block located in #{__FILE__}"
+    # Put your resource owner authentication logic here.
+    # Example implementation:
+    #   User.find_by(id: session[:user_id]) || redirect_to(new_user_session_url)
+  end
+
+  # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
+  # file then you need to declare this block in order to restrict access to the web interface for
+  # adding oauth authorized applications. In other case it will return 403 Forbidden response
+  # every time somebody will try to access the admin web interface.
+  #
+  # admin_authenticator do
+  #   # Put your admin authentication logic here.
+  #   # Example implementation:
+  #
+  #   if current_user
+  #     head :forbidden unless current_user.admin?
+  #   else
+  #     redirect_to sign_in_url
+  #   end
+  # end
+
+  # You can use your own model classes if you need to extend (or even override) default
+  # Doorkeeper models such as `Application`, `AccessToken` and `AccessGrant.
+  #
+  # Be default Doorkeeper ActiveRecord ORM uses it's own classes:
+  #
+  # access_token_class "Doorkeeper::AccessToken"
+  # access_grant_class "Doorkeeper::AccessGrant"
+  # application_class "Doorkeeper::Application"
+  #
+  # Don't forget to include Doorkeeper ORM mixins into your custom models:
+  #
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken - for access token
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant - for access grant
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::Application - for application (OAuth2 clients)
+  #
+  # For example:
+  #
+  # access_token_class "MyAccessToken"
+  #
+  # class MyAccessToken < ApplicationRecord
+  #   include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+  #
+  #   self.table_name = "hey_i_wanna_my_name"
+  #
+  #   def destroy_me!
+  #     destroy
+  #   end
+  # end
+
+  # Enables polymorphic Resource Owner association for Access Tokens and Access Grants.
+  # By default this option is disabled.
+  #
+  # Make sure you properly setup you database and have all the required columns (run
+  # `bundle exec rails generate doorkeeper:enable_polymorphic_resource_owner` and execute Rails
+  # migrations).
+  #
+  # If this option enabled, Doorkeeper will store not only Resource Owner primary key
+  # value, but also it's type (class name). See "Polymorphic Associations" section of
+  # Rails guides: https://guides.rubyonrails.org/association_basics.html#polymorphic-associations
+  #
+  # [NOTE] If you apply this option on already existing project don't forget to manually
+  # update `resource_owner_type` column in the database and fix migration template as it will
+  # set NOT NULL constraint for Access Grants table.
+  #
+  # use_polymorphic_resource_owner
+
+  # If you are planning to use Doorkeeper in Rails 5 API-only application, then you might
+  # want to use API mode that will skip all the views management and change the way how
+  # Doorkeeper responds to a requests.
+  #
+  # api_only
+
+  # Enforce token request content type to application/x-www-form-urlencoded.
+  # It is not enabled by default to not break prior versions of the gem.
+  #
+  # enforce_content_type
+
+  # Authorization Code expiration time (default: 10 minutes).
+  #
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default: 2 hours).
+  # If you want to disable expiration, set this to `nil`.
+  #
+  # access_token_expires_in 2.hours
+
+  # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
+  # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to
+  # +access_token_expires_in+ configuration option value. If you really need to issue a
+  # non-expiring access token (which is not recommended) then you need to return
+  # Float::INFINITY from this block.
+  #
+  # `context` has the following properties available:
+  #
+  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #
+  # custom_access_token_expires_in do |context|
+  #   context.client.application.additional_settings.implicit_oauth_expiration
+  # end
+
+  # Use a custom class for generating the access token.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-access-token-generator
+  #
+  # access_token_generator '::Doorkeeper::JWT'
+
+  # The controller +Doorkeeper::ApplicationController+ inherits from.
+  # Defaults to +ActionController::Base+ unless +api_only+ is set, which changes the default to
+  # +ActionController::API+. The return value of this option must be a stringified class name.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-base-controller
+  #
+  # base_controller 'ApplicationController'
+
+  # Reuse access token for the same resource owner within an application (disabled by default).
+  #
+  # This option protects your application from creating new tokens before old valid one becomes
+  # expired so your database doesn't bloat. Keep in mind that when this option is `on` Doorkeeper
+  # doesn't updates existing token expiration time, it will create a new token instead.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+  #
+  # You can not enable this option together with +hash_token_secrets+.
+  #
+  # reuse_access_token
+
+  # In case you enabled `reuse_access_token` option Doorkeeper will try to find matching
+  # token using `matching_token_for` Access Token API that searches for valid records
+  # in batches in order not to pollute the memory with all the database records. By default
+  # Doorkeeper uses batch size of 10 000 records. You can increase or decrease this value
+  # depending on your needs and server capabilities.
+  #
+  # token_lookup_batch_size 10_000
+
+  # Set a limit for token_reuse if using reuse_access_token option
+  #
+  # This option limits token_reusability to some extent.
+  # If not set then access_token will be reused unless it expires.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
+  #
+  # This option should be a percentage(i.e. (0,100])
+  #
+  # token_reuse_limit 100
+
+  # Only allow one valid access token obtained via client credentials
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # When enabling this option, make sure that you do not expect multiple processes
+  # using the same credentials at the same time (e.g. web servers spanning
+  # multiple machines and/or processes).
+  #
+  # revoke_previous_client_credentials_token
+
+  # Hash access and refresh tokens before persisting them.
+  # This will disable the possibility to use +reuse_access_token+
+  # since plain values can no longer be retrieved.
+  #
+  # Note: If you are already a user of doorkeeper and have existing tokens
+  # in your installation, they will be invalid without enabling the additional
+  # setting `fallback_to_plain_secrets` below.
+  #
+  # hash_token_secrets
+  # By default, token secrets will be hashed using the
+  # +Doorkeeper::Hashing::SHA256+ strategy.
+  #
+  # If you wish to use another hashing implementation, you can override
+  # this strategy as follows:
+  #
+  # hash_token_secrets using: '::Doorkeeper::Hashing::MyCustomHashImpl'
+  #
+  # Keep in mind that changing the hashing function will invalidate all existing
+  # secrets, if there are any.
+
+  # Hash application secrets before persisting them.
+  #
+  # hash_application_secrets
+  #
+  # By default, applications will be hashed
+  # with the +Doorkeeper::SecretStoring::SHA256+ strategy.
+  #
+  # If you wish to use bcrypt for application secret hashing, uncomment
+  # this line instead:
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
+
+  # When the above option is enabled, and a hashed token or secret is not found,
+  # you can allow to fall back to another strategy. For users upgrading
+  # doorkeeper and wishing to enable hashing, you will probably want to enable
+  # the fallback to plain tokens.
+  #
+  # This will ensure that old access tokens and secrets
+  # will remain valid even if the hashing above is enabled.
+  #
+  # fallback_to_plain_secrets
+
+  # Issue access tokens with refresh token (disabled by default), you may also
+  # pass a block which accepts `context` to customize when to give a refresh
+  # token or not. Similar to +custom_access_token_expires_in+, `context` has
+  # the following properties:
+  #
+  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #
+  # use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
+  # a registered application
+  # NOTE: you must also run the rails g doorkeeper:application_owner generator
+  # to provide the necessary support
+  #
+  # enable_application_owner confirmation: false
+
+  # Define access token scopes for your provider
+  # For more information go to
+  # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
+  #
+  # default_scopes  :public
+  # optional_scopes :write, :update
+
+  # Allows to restrict only certain scopes for grant_type.
+  # By default, all the scopes will be available for all the grant types.
+  #
+  # Keys to this hash should be the name of grant_type and
+  # values should be the array of scopes for that grant type.
+  # Note: scopes should be from configured_scopes (i.e. default or optional)
+  #
+  # scopes_by_grant_type password: [:write], client_credentials: [:update]
+
+  # Forbids creating/updating applications with arbitrary scopes that are
+  # not in configuration, i.e. +default_scopes+ or +optional_scopes+.
+  # (disabled by default)
+  #
+  # enforce_configured_scopes
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+  # by default in non-development environments). OAuth2 delegates security in
+  # communication to the HTTPS protocol so it is wise to keep this enabled.
+  #
+  # Callable objects such as proc, lambda, block or any object that responds to
+  # #call can be used in order to allow conditional checks (to allow non-SSL
+  # redirects to localhost for example).
+  #
+  # force_ssl_in_redirect_uri !Rails.env.development?
+  #
+  # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+
+  # Specify what redirect URI's you want to block during Application creation.
+  # Any redirect URI is whitelisted by default.
+  #
+  # You can use this option in order to forbid URI's with 'javascript' scheme
+  # for example.
+  #
+  # forbid_redirect_uri { |uri| uri.scheme.to_s.downcase == 'javascript' }
+
+  # Allows to set blank redirect URIs for Applications in case Doorkeeper configured
+  # to use URI-less OAuth grant flows like Client Credentials or Resource Owner
+  # Password Credentials. The option is on by default and checks configured grant
+  # types, but you **need** to manually drop `NOT NULL` constraint from `redirect_uri`
+  # column for `oauth_applications` database table.
+  #
+  # You can completely disable this feature with:
+  #
+  # allow_blank_redirect_uri false
+  #
+  # Or you can define your custom check:
+  #
+  # allow_blank_redirect_uri do |grant_flows, client|
+  #   client.superapp?
+  # end
+
+  # Specify how authorization errors should be handled.
+  # By default, doorkeeper renders json errors when access token
+  # is invalid, expired, revoked or has invalid scopes.
+  #
+  # If you want to render error response yourself (i.e. rescue exceptions),
+  # set +handle_auth_errors+ to `:raise` and rescue Doorkeeper::Errors::InvalidToken
+  # or following specific errors:
+  #
+  #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
+  #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
+  #
+  # handle_auth_errors :raise
+
+  # Customize token introspection response.
+  # Allows to add your own fields to default one that are required by the OAuth spec
+  # for the introspection response. It could be `sub`, `aud` and so on.
+  # This configuration option can be a proc, lambda or any Ruby object responds
+  # to `.call` method and result of it's invocation must be a Hash.
+  #
+  # custom_introspection_response do |token, context|
+  #   {
+  #     "sub": "Z5O3upPC88QrAjx00dis",
+  #     "aud": "https://protected.example.net/resource",
+  #     "username": User.find(token.resource_owner_id).username
+  #   }
+  # end
+  #
+  # or
+  #
+  # custom_introspection_response CustomIntrospectionResponder
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables authorization_code and
+  # client_credentials.
+  #
+  # implicit and password grant flows have risks that you should understand
+  # before enabling:
+  #   http://tools.ietf.org/html/rfc6819#section-4.4.2
+  #   http://tools.ietf.org/html/rfc6819#section-4.4.3
+  #
+  # grant_flows %w[authorization_code client_credentials]
+
+  # Allows to customize OAuth grant flows that +each+ application support.
+  # You can configure a custom block (or use a class respond to `#call`) that must
+  # return `true` in case Application instance supports requested OAuth grant flow
+  # during the authorization request to the server. This configuration +doesn't+
+  # set flows per application, it only allows to check if application supports
+  # specific grant flow.
+  #
+  # For example you can add an additional database column to `oauth_applications` table,
+  # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
+  # be used with this application there. Then when authorization requested Doorkeeper
+  # will call this block to check if specific Application (passed with client_id and/or
+  # client_secret) is allowed to perform the request for the specific grant type
+  # (authorization, password, client_credentials, etc).
+  #
+  # Example of the block:
+  #
+  #   ->(flow, client) { client.grant_flows.include?(flow) }
+  #
+  # In case this option invocation result is `false`, Doorkeeper server returns
+  # :unauthorized_client error and stops the request.
+  #
+  # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
+  # @return [Boolean] `true` if allow or `false` if forbid the request
+  #
+  # allow_grant_flow_for_client do |grant_flow, client|
+  #   # `grant_flows` is an Array column with grant
+  #   # flows that application supports
+  #
+  #   client.grant_flows.include?(grant_flow)
+  # end
+
+  # If you need arbitrary Resource Owner-Client authorization you can enable this option
+  # and implement the check your need. Config option must respond to #call and return
+  # true in case resource owner authorized for the specific application or false in other
+  # cases.
+  #
+  # Be default all Resource Owners are authorized to any Client (application).
+  #
+  # authorize_resource_owner_for_client do |client, resource_owner|
+  #   resource_owner.admin? || client.owners_whitelist.include?(resource_owner)
+  # end
+
+  # Hook into the strategies' request & response life-cycle in case your
+  # application needs advanced customization or logging:
+  #
+  # before_successful_strategy_response do |request|
+  #   puts "BEFORE HOOK FIRED! #{request}"
+  # end
+  #
+  # after_successful_strategy_response do |request, response|
+  #   puts "AFTER HOOK FIRED! #{request}, #{response}"
+  # end
+
+  # Hook into Authorization flow in order to implement Single Sign Out
+  # or add any other functionality. Inside the block you have an access
+  # to `controller` (authorizations controller instance) and `context`
+  # (Doorkeeper::OAuth::Hooks::Context instance) which provides pre auth
+  # or auth objects with issued token based on hook type (before or after).
+  #
+  # before_successful_authorization do |controller, context|
+  #   Rails.logger.info(controller.request.params.inspect)
+  #
+  #   Rails.logger.info(context.pre_auth.inspect)
+  # end
+  #
+  # after_successful_authorization do |controller, context|
+  #   controller.session[:logout_urls] <<
+  #     Doorkeeper::Application
+  #       .find_by(controller.request.params.slice(:redirect_uri))
+  #       .logout_uri
+  #
+  #   Rails.logger.info(context.auth.inspect)
+  #   Rails.logger.info(context.issued_token)
+  # end
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with a trusted application.
+  #
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # Configure custom constraints for the Token Introspection request.
+  # By default this configuration option allows to introspect a token by another
+  # token of the same application, OR to introspect the token that belongs to
+  # authorized client (from authenticated client) OR when token doesn't
+  # belong to any client (public token). Otherwise requester has no access to the
+  # introspection and it will return response as stated in the RFC.
+  #
+  # Block arguments:
+  #
+  # @param token [Doorkeeper::AccessToken]
+  #   token to be introspected
+  #
+  # @param authorized_client [Doorkeeper::Application]
+  #   authorized client (if request is authorized using Basic auth with
+  #   Client Credentials for example)
+  #
+  # @param authorized_token [Doorkeeper::AccessToken]
+  #   Bearer token used to authorize the request
+  #
+  # In case the block returns `nil` or `false` introspection responses with 401 status code
+  # when using authorized token to introspect, or you'll get 200 with { "active": false } body
+  # when using authorized client to introspect as stated in the
+  # RFC 7662 section 2.2. Introspection Response.
+  #
+  # Using with caution:
+  # Keep in mind that these three parameters pass to block can be nil as following case:
+  #  `authorized_client` is nil if and only if `authorized_token` is present, and vice versa.
+  #  `token` will be nil if and only if `authorized_token` is present.
+  # So remember to use `&` or check if it is present before calling method on
+  # them to make sure you doesn't get NoMethodError exception.
+  #
+  # You can define your custom check:
+  #
+  # allow_token_introspection do |token, authorized_client, authorized_token|
+  #   if authorized_token
+  #     # customize: require `introspection` scope
+  #     authorized_token.application == token&.application ||
+  #       authorized_token.scopes.include?("introspection")
+  #   elsif token.application
+  #     # `protected_resource` is a new database boolean column, for example
+  #     authorized_client == token.application || authorized_client.protected_resource?
+  #   else
+  #     # public token (when token.application is nil, token doesn't belong to any application)
+  #     true
+  #   end
+  # end
+  #
+  # Or you can completely disable any token introspection:
+  #
+  # allow_token_introspection false
+  #
+  # If you need to block the request at all, then configure your routes.rb or web-server
+  # like nginx to forbid the request.
+
+  # WWW-Authenticate Realm (default: "Doorkeeper").
+  #
+  # realm "Doorkeeper"
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -9,7 +9,9 @@ Doorkeeper.configure do
   end
 
   admin_authenticator do
-    current_user || redirect_to(new_user_session_url)
+    unless current_user.admin_users === true
+      redirect_to new_user_session_url
+    end
   end
 
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,489 +1,506 @@
-# frozen_string_literal: true
-
-Doorkeeper.configure do
-  # Change the ORM that doorkeeper will use (requires ORM extensions installed).
-  # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms
-  orm :active_record
-
-  # This block will be called to check whether the resource owner is authenticated or not.
+Doorkeeper.configure do  
+  default_scopes :public
+  
   resource_owner_authenticator do
-    raise "Please configure doorkeeper resource_owner_authenticator block located in #{__FILE__}"
-    # Put your resource owner authentication logic here.
-    # Example implementation:
-    #   User.find_by(id: session[:user_id]) || redirect_to(new_user_session_url)
+    current_user || begin
+      session[:user_return_to] = request.fullpath
+      redirect_to new_user_session_url
+    end
   end
 
-  # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
-  # file then you need to declare this block in order to restrict access to the web interface for
-  # adding oauth authorized applications. In other case it will return 403 Forbidden response
-  # every time somebody will try to access the admin web interface.
-  #
-  # admin_authenticator do
-  #   # Put your admin authentication logic here.
-  #   # Example implementation:
-  #
-  #   if current_user
-  #     head :forbidden unless current_user.admin?
-  #   else
-  #     redirect_to sign_in_url
-  #   end
-  # end
+  admin_authenticator do
+    current_user || redirect_to(new_user_session_url)
+  end
 
-  # You can use your own model classes if you need to extend (or even override) default
-  # Doorkeeper models such as `Application`, `AccessToken` and `AccessGrant.
-  #
-  # Be default Doorkeeper ActiveRecord ORM uses it's own classes:
-  #
-  # access_token_class "Doorkeeper::AccessToken"
-  # access_grant_class "Doorkeeper::AccessGrant"
-  # application_class "Doorkeeper::Application"
-  #
-  # Don't forget to include Doorkeeper ORM mixins into your custom models:
-  #
-  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken - for access token
-  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant - for access grant
-  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::Application - for application (OAuth2 clients)
-  #
-  # For example:
-  #
-  # access_token_class "MyAccessToken"
-  #
-  # class MyAccessToken < ApplicationRecord
-  #   include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
-  #
-  #   self.table_name = "hey_i_wanna_my_name"
-  #
-  #   def destroy_me!
-  #     destroy
-  #   end
-  # end
-
-  # Enables polymorphic Resource Owner association for Access Tokens and Access Grants.
-  # By default this option is disabled.
-  #
-  # Make sure you properly setup you database and have all the required columns (run
-  # `bundle exec rails generate doorkeeper:enable_polymorphic_resource_owner` and execute Rails
-  # migrations).
-  #
-  # If this option enabled, Doorkeeper will store not only Resource Owner primary key
-  # value, but also it's type (class name). See "Polymorphic Associations" section of
-  # Rails guides: https://guides.rubyonrails.org/association_basics.html#polymorphic-associations
-  #
-  # [NOTE] If you apply this option on already existing project don't forget to manually
-  # update `resource_owner_type` column in the database and fix migration template as it will
-  # set NOT NULL constraint for Access Grants table.
-  #
-  # use_polymorphic_resource_owner
-
-  # If you are planning to use Doorkeeper in Rails 5 API-only application, then you might
-  # want to use API mode that will skip all the views management and change the way how
-  # Doorkeeper responds to a requests.
-  #
-  # api_only
-
-  # Enforce token request content type to application/x-www-form-urlencoded.
-  # It is not enabled by default to not break prior versions of the gem.
-  #
-  # enforce_content_type
-
-  # Authorization Code expiration time (default: 10 minutes).
-  #
-  # authorization_code_expires_in 10.minutes
-
-  # Access token expiration time (default: 2 hours).
-  # If you want to disable expiration, set this to `nil`.
-  #
-  # access_token_expires_in 2.hours
-
-  # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
-  # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to
-  # +access_token_expires_in+ configuration option value. If you really need to issue a
-  # non-expiring access token (which is not recommended) then you need to return
-  # Float::INFINITY from this block.
-  #
-  # `context` has the following properties available:
-  #
-  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
-  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
-  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
-  #
-  # custom_access_token_expires_in do |context|
-  #   context.client.application.additional_settings.implicit_oauth_expiration
-  # end
-
-  # Use a custom class for generating the access token.
-  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-access-token-generator
-  #
-  # access_token_generator '::Doorkeeper::JWT'
-
-  # The controller +Doorkeeper::ApplicationController+ inherits from.
-  # Defaults to +ActionController::Base+ unless +api_only+ is set, which changes the default to
-  # +ActionController::API+. The return value of this option must be a stringified class name.
-  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-base-controller
-  #
-  # base_controller 'ApplicationController'
-
-  # Reuse access token for the same resource owner within an application (disabled by default).
-  #
-  # This option protects your application from creating new tokens before old valid one becomes
-  # expired so your database doesn't bloat. Keep in mind that when this option is `on` Doorkeeper
-  # doesn't updates existing token expiration time, it will create a new token instead.
-  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
-  #
-  # You can not enable this option together with +hash_token_secrets+.
-  #
-  # reuse_access_token
-
-  # In case you enabled `reuse_access_token` option Doorkeeper will try to find matching
-  # token using `matching_token_for` Access Token API that searches for valid records
-  # in batches in order not to pollute the memory with all the database records. By default
-  # Doorkeeper uses batch size of 10 000 records. You can increase or decrease this value
-  # depending on your needs and server capabilities.
-  #
-  # token_lookup_batch_size 10_000
-
-  # Set a limit for token_reuse if using reuse_access_token option
-  #
-  # This option limits token_reusability to some extent.
-  # If not set then access_token will be reused unless it expires.
-  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
-  #
-  # This option should be a percentage(i.e. (0,100])
-  #
-  # token_reuse_limit 100
-
-  # Only allow one valid access token obtained via client credentials
-  # per client. If a new access token is obtained before the old one
-  # expired, the old one gets revoked (disabled by default)
-  #
-  # When enabling this option, make sure that you do not expect multiple processes
-  # using the same credentials at the same time (e.g. web servers spanning
-  # multiple machines and/or processes).
-  #
-  # revoke_previous_client_credentials_token
-
-  # Hash access and refresh tokens before persisting them.
-  # This will disable the possibility to use +reuse_access_token+
-  # since plain values can no longer be retrieved.
-  #
-  # Note: If you are already a user of doorkeeper and have existing tokens
-  # in your installation, they will be invalid without enabling the additional
-  # setting `fallback_to_plain_secrets` below.
-  #
-  # hash_token_secrets
-  # By default, token secrets will be hashed using the
-  # +Doorkeeper::Hashing::SHA256+ strategy.
-  #
-  # If you wish to use another hashing implementation, you can override
-  # this strategy as follows:
-  #
-  # hash_token_secrets using: '::Doorkeeper::Hashing::MyCustomHashImpl'
-  #
-  # Keep in mind that changing the hashing function will invalidate all existing
-  # secrets, if there are any.
-
-  # Hash application secrets before persisting them.
-  #
-  # hash_application_secrets
-  #
-  # By default, applications will be hashed
-  # with the +Doorkeeper::SecretStoring::SHA256+ strategy.
-  #
-  # If you wish to use bcrypt for application secret hashing, uncomment
-  # this line instead:
-  #
-  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
-
-  # When the above option is enabled, and a hashed token or secret is not found,
-  # you can allow to fall back to another strategy. For users upgrading
-  # doorkeeper and wishing to enable hashing, you will probably want to enable
-  # the fallback to plain tokens.
-  #
-  # This will ensure that old access tokens and secrets
-  # will remain valid even if the hashing above is enabled.
-  #
-  # fallback_to_plain_secrets
-
-  # Issue access tokens with refresh token (disabled by default), you may also
-  # pass a block which accepts `context` to customize when to give a refresh
-  # token or not. Similar to +custom_access_token_expires_in+, `context` has
-  # the following properties:
-  #
-  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
-  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
-  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
-  #
-  # use_refresh_token
-
-  # Provide support for an owner to be assigned to each registered application (disabled by default)
-  # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
-  # a registered application
-  # NOTE: you must also run the rails g doorkeeper:application_owner generator
-  # to provide the necessary support
-  #
-  # enable_application_owner confirmation: false
-
-  # Define access token scopes for your provider
-  # For more information go to
-  # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
-  #
-  # default_scopes  :public
-  # optional_scopes :write, :update
-
-  # Allows to restrict only certain scopes for grant_type.
-  # By default, all the scopes will be available for all the grant types.
-  #
-  # Keys to this hash should be the name of grant_type and
-  # values should be the array of scopes for that grant type.
-  # Note: scopes should be from configured_scopes (i.e. default or optional)
-  #
-  # scopes_by_grant_type password: [:write], client_credentials: [:update]
-
-  # Forbids creating/updating applications with arbitrary scopes that are
-  # not in configuration, i.e. +default_scopes+ or +optional_scopes+.
-  # (disabled by default)
-  #
-  # enforce_configured_scopes
-
-  # Change the way client credentials are retrieved from the request object.
-  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
-  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
-  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
-  # for more information on customization
-  #
-  # client_credentials :from_basic, :from_params
-
-  # Change the way access token is authenticated from the request object.
-  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
-  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
-  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
-  # for more information on customization
-  #
-  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
-
-  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
-  # by default in non-development environments). OAuth2 delegates security in
-  # communication to the HTTPS protocol so it is wise to keep this enabled.
-  #
-  # Callable objects such as proc, lambda, block or any object that responds to
-  # #call can be used in order to allow conditional checks (to allow non-SSL
-  # redirects to localhost for example).
-  #
-  # force_ssl_in_redirect_uri !Rails.env.development?
-  #
-  # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
-
-  # Specify what redirect URI's you want to block during Application creation.
-  # Any redirect URI is whitelisted by default.
-  #
-  # You can use this option in order to forbid URI's with 'javascript' scheme
-  # for example.
-  #
-  # forbid_redirect_uri { |uri| uri.scheme.to_s.downcase == 'javascript' }
-
-  # Allows to set blank redirect URIs for Applications in case Doorkeeper configured
-  # to use URI-less OAuth grant flows like Client Credentials or Resource Owner
-  # Password Credentials. The option is on by default and checks configured grant
-  # types, but you **need** to manually drop `NOT NULL` constraint from `redirect_uri`
-  # column for `oauth_applications` database table.
-  #
-  # You can completely disable this feature with:
-  #
-  # allow_blank_redirect_uri false
-  #
-  # Or you can define your custom check:
-  #
-  # allow_blank_redirect_uri do |grant_flows, client|
-  #   client.superapp?
-  # end
-
-  # Specify how authorization errors should be handled.
-  # By default, doorkeeper renders json errors when access token
-  # is invalid, expired, revoked or has invalid scopes.
-  #
-  # If you want to render error response yourself (i.e. rescue exceptions),
-  # set +handle_auth_errors+ to `:raise` and rescue Doorkeeper::Errors::InvalidToken
-  # or following specific errors:
-  #
-  #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
-  #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
-  #
-  # handle_auth_errors :raise
-
-  # Customize token introspection response.
-  # Allows to add your own fields to default one that are required by the OAuth spec
-  # for the introspection response. It could be `sub`, `aud` and so on.
-  # This configuration option can be a proc, lambda or any Ruby object responds
-  # to `.call` method and result of it's invocation must be a Hash.
-  #
-  # custom_introspection_response do |token, context|
-  #   {
-  #     "sub": "Z5O3upPC88QrAjx00dis",
-  #     "aud": "https://protected.example.net/resource",
-  #     "username": User.find(token.resource_owner_id).username
-  #   }
-  # end
-  #
-  # or
-  #
-  # custom_introspection_response CustomIntrospectionResponder
-
-  # Specify what grant flows are enabled in array of Strings. The valid
-  # strings and the flows they enable are:
-  #
-  # "authorization_code" => Authorization Code Grant Flow
-  # "implicit"           => Implicit Grant Flow
-  # "password"           => Resource Owner Password Credentials Grant Flow
-  # "client_credentials" => Client Credentials Grant Flow
-  #
-  # If not specified, Doorkeeper enables authorization_code and
-  # client_credentials.
-  #
-  # implicit and password grant flows have risks that you should understand
-  # before enabling:
-  #   http://tools.ietf.org/html/rfc6819#section-4.4.2
-  #   http://tools.ietf.org/html/rfc6819#section-4.4.3
-  #
-  # grant_flows %w[authorization_code client_credentials]
-
-  # Allows to customize OAuth grant flows that +each+ application support.
-  # You can configure a custom block (or use a class respond to `#call`) that must
-  # return `true` in case Application instance supports requested OAuth grant flow
-  # during the authorization request to the server. This configuration +doesn't+
-  # set flows per application, it only allows to check if application supports
-  # specific grant flow.
-  #
-  # For example you can add an additional database column to `oauth_applications` table,
-  # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
-  # be used with this application there. Then when authorization requested Doorkeeper
-  # will call this block to check if specific Application (passed with client_id and/or
-  # client_secret) is allowed to perform the request for the specific grant type
-  # (authorization, password, client_credentials, etc).
-  #
-  # Example of the block:
-  #
-  #   ->(flow, client) { client.grant_flows.include?(flow) }
-  #
-  # In case this option invocation result is `false`, Doorkeeper server returns
-  # :unauthorized_client error and stops the request.
-  #
-  # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
-  # @return [Boolean] `true` if allow or `false` if forbid the request
-  #
-  # allow_grant_flow_for_client do |grant_flow, client|
-  #   # `grant_flows` is an Array column with grant
-  #   # flows that application supports
-  #
-  #   client.grant_flows.include?(grant_flow)
-  # end
-
-  # If you need arbitrary Resource Owner-Client authorization you can enable this option
-  # and implement the check your need. Config option must respond to #call and return
-  # true in case resource owner authorized for the specific application or false in other
-  # cases.
-  #
-  # Be default all Resource Owners are authorized to any Client (application).
-  #
-  # authorize_resource_owner_for_client do |client, resource_owner|
-  #   resource_owner.admin? || client.owners_whitelist.include?(resource_owner)
-  # end
-
-  # Hook into the strategies' request & response life-cycle in case your
-  # application needs advanced customization or logging:
-  #
-  # before_successful_strategy_response do |request|
-  #   puts "BEFORE HOOK FIRED! #{request}"
-  # end
-  #
-  # after_successful_strategy_response do |request, response|
-  #   puts "AFTER HOOK FIRED! #{request}, #{response}"
-  # end
-
-  # Hook into Authorization flow in order to implement Single Sign Out
-  # or add any other functionality. Inside the block you have an access
-  # to `controller` (authorizations controller instance) and `context`
-  # (Doorkeeper::OAuth::Hooks::Context instance) which provides pre auth
-  # or auth objects with issued token based on hook type (before or after).
-  #
-  # before_successful_authorization do |controller, context|
-  #   Rails.logger.info(controller.request.params.inspect)
-  #
-  #   Rails.logger.info(context.pre_auth.inspect)
-  # end
-  #
-  # after_successful_authorization do |controller, context|
-  #   controller.session[:logout_urls] <<
-  #     Doorkeeper::Application
-  #       .find_by(controller.request.params.slice(:redirect_uri))
-  #       .logout_uri
-  #
-  #   Rails.logger.info(context.auth.inspect)
-  #   Rails.logger.info(context.issued_token)
-  # end
-
-  # Under some circumstances you might want to have applications auto-approved,
-  # so that the user skips the authorization step.
-  # For example if dealing with a trusted application.
-  #
-  # skip_authorization do |resource_owner, client|
-  #   client.superapp? or resource_owner.admin?
-  # end
-
-  # Configure custom constraints for the Token Introspection request.
-  # By default this configuration option allows to introspect a token by another
-  # token of the same application, OR to introspect the token that belongs to
-  # authorized client (from authenticated client) OR when token doesn't
-  # belong to any client (public token). Otherwise requester has no access to the
-  # introspection and it will return response as stated in the RFC.
-  #
-  # Block arguments:
-  #
-  # @param token [Doorkeeper::AccessToken]
-  #   token to be introspected
-  #
-  # @param authorized_client [Doorkeeper::Application]
-  #   authorized client (if request is authorized using Basic auth with
-  #   Client Credentials for example)
-  #
-  # @param authorized_token [Doorkeeper::AccessToken]
-  #   Bearer token used to authorize the request
-  #
-  # In case the block returns `nil` or `false` introspection responses with 401 status code
-  # when using authorized token to introspect, or you'll get 200 with { "active": false } body
-  # when using authorized client to introspect as stated in the
-  # RFC 7662 section 2.2. Introspection Response.
-  #
-  # Using with caution:
-  # Keep in mind that these three parameters pass to block can be nil as following case:
-  #  `authorized_client` is nil if and only if `authorized_token` is present, and vice versa.
-  #  `token` will be nil if and only if `authorized_token` is present.
-  # So remember to use `&` or check if it is present before calling method on
-  # them to make sure you doesn't get NoMethodError exception.
-  #
-  # You can define your custom check:
-  #
-  # allow_token_introspection do |token, authorized_client, authorized_token|
-  #   if authorized_token
-  #     # customize: require `introspection` scope
-  #     authorized_token.application == token&.application ||
-  #       authorized_token.scopes.include?("introspection")
-  #   elsif token.application
-  #     # `protected_resource` is a new database boolean column, for example
-  #     authorized_client == token.application || authorized_client.protected_resource?
-  #   else
-  #     # public token (when token.application is nil, token doesn't belong to any application)
-  #     true
-  #   end
-  # end
-  #
-  # Or you can completely disable any token introspection:
-  #
-  # allow_token_introspection false
-  #
-  # If you need to block the request at all, then configure your routes.rb or web-server
-  # like nginx to forbid the request.
-
-  # WWW-Authenticate Realm (default: "Doorkeeper").
-  #
-  # realm "Doorkeeper"
 end
+
+
+# # frozen_string_literal: true
+
+# Doorkeeper.configure do
+#   # Change the ORM that doorkeeper will use (requires ORM extensions installed).
+#   # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms
+#   orm :active_record
+
+#   # This block will be called to check whether the resource owner is authenticated or not.
+#   resource_owner_authenticator do
+#     raise "Please configure doorkeeper resource_owner_authenticator block located in #{__FILE__}"
+#     # Put your resource owner authentication logic here.
+#     # Example implementation:
+#     #   User.find_by(id: session[:user_id]) || redirect_to(new_user_session_url)
+#   end
+
+#   # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
+#   # file then you need to declare this block in order to restrict access to the web interface for
+#   # adding oauth authorized applications. In other case it will return 403 Forbidden response
+#   # every time somebody will try to access the admin web interface.
+#   #
+#   # admin_authenticator do
+#   #   # Put your admin authentication logic here.
+#   #   # Example implementation:
+#   #
+#   #   if current_user
+#   #     head :forbidden unless current_user.admin?
+#   #   else
+#   #     redirect_to sign_in_url
+#   #   end
+#   # end
+
+#   # You can use your own model classes if you need to extend (or even override) default
+#   # Doorkeeper models such as `Application`, `AccessToken` and `AccessGrant.
+#   #
+#   # Be default Doorkeeper ActiveRecord ORM uses it's own classes:
+#   #
+#   # access_token_class "Doorkeeper::AccessToken"
+#   # access_grant_class "Doorkeeper::AccessGrant"
+#   # application_class "Doorkeeper::Application"
+#   #
+#   # Don't forget to include Doorkeeper ORM mixins into your custom models:
+#   #
+#   #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken - for access token
+#   #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant - for access grant
+#   #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::Application - for application (OAuth2 clients)
+#   #
+#   # For example:
+#   #
+#   # access_token_class "MyAccessToken"
+#   #
+#   # class MyAccessToken < ApplicationRecord
+#   #   include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+#   #
+#   #   self.table_name = "hey_i_wanna_my_name"
+#   #
+#   #   def destroy_me!
+#   #     destroy
+#   #   end
+#   # end
+
+#   # Enables polymorphic Resource Owner association for Access Tokens and Access Grants.
+#   # By default this option is disabled.
+#   #
+#   # Make sure you properly setup you database and have all the required columns (run
+#   # `bundle exec rails generate doorkeeper:enable_polymorphic_resource_owner` and execute Rails
+#   # migrations).
+#   #
+#   # If this option enabled, Doorkeeper will store not only Resource Owner primary key
+#   # value, but also it's type (class name). See "Polymorphic Associations" section of
+#   # Rails guides: https://guides.rubyonrails.org/association_basics.html#polymorphic-associations
+#   #
+#   # [NOTE] If you apply this option on already existing project don't forget to manually
+#   # update `resource_owner_type` column in the database and fix migration template as it will
+#   # set NOT NULL constraint for Access Grants table.
+#   #
+#   # use_polymorphic_resource_owner
+
+#   # If you are planning to use Doorkeeper in Rails 5 API-only application, then you might
+#   # want to use API mode that will skip all the views management and change the way how
+#   # Doorkeeper responds to a requests.
+#   #
+#   # api_only
+
+#   # Enforce token request content type to application/x-www-form-urlencoded.
+#   # It is not enabled by default to not break prior versions of the gem.
+#   #
+#   # enforce_content_type
+
+#   # Authorization Code expiration time (default: 10 minutes).
+#   #
+#   # authorization_code_expires_in 10.minutes
+
+#   # Access token expiration time (default: 2 hours).
+#   # If you want to disable expiration, set this to `nil`.
+#   #
+#   # access_token_expires_in 2.hours
+
+#   # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
+#   # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to
+#   # +access_token_expires_in+ configuration option value. If you really need to issue a
+#   # non-expiring access token (which is not recommended) then you need to return
+#   # Float::INFINITY from this block.
+#   #
+#   # `context` has the following properties available:
+#   #
+#   # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+#   # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+#   # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+#   #
+#   # custom_access_token_expires_in do |context|
+#   #   context.client.application.additional_settings.implicit_oauth_expiration
+#   # end
+
+#   # Use a custom class for generating the access token.
+#   # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-access-token-generator
+#   #
+#   # access_token_generator '::Doorkeeper::JWT'
+
+#   # The controller +Doorkeeper::ApplicationController+ inherits from.
+#   # Defaults to +ActionController::Base+ unless +api_only+ is set, which changes the default to
+#   # +ActionController::API+. The return value of this option must be a stringified class name.
+#   # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-base-controller
+#   #
+#   # base_controller 'ApplicationController'
+
+#   # Reuse access token for the same resource owner within an application (disabled by default).
+#   #
+#   # This option protects your application from creating new tokens before old valid one becomes
+#   # expired so your database doesn't bloat. Keep in mind that when this option is `on` Doorkeeper
+#   # doesn't updates existing token expiration time, it will create a new token instead.
+#   # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+#   #
+#   # You can not enable this option together with +hash_token_secrets+.
+#   #
+#   # reuse_access_token
+
+#   # In case you enabled `reuse_access_token` option Doorkeeper will try to find matching
+#   # token using `matching_token_for` Access Token API that searches for valid records
+#   # in batches in order not to pollute the memory with all the database records. By default
+#   # Doorkeeper uses batch size of 10 000 records. You can increase or decrease this value
+#   # depending on your needs and server capabilities.
+#   #
+#   # token_lookup_batch_size 10_000
+
+#   # Set a limit for token_reuse if using reuse_access_token option
+#   #
+#   # This option limits token_reusability to some extent.
+#   # If not set then access_token will be reused unless it expires.
+#   # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
+#   #
+#   # This option should be a percentage(i.e. (0,100])
+#   #
+#   # token_reuse_limit 100
+
+#   # Only allow one valid access token obtained via client credentials
+#   # per client. If a new access token is obtained before the old one
+#   # expired, the old one gets revoked (disabled by default)
+#   #
+#   # When enabling this option, make sure that you do not expect multiple processes
+#   # using the same credentials at the same time (e.g. web servers spanning
+#   # multiple machines and/or processes).
+#   #
+#   # revoke_previous_client_credentials_token
+
+#   # Hash access and refresh tokens before persisting them.
+#   # This will disable the possibility to use +reuse_access_token+
+#   # since plain values can no longer be retrieved.
+#   #
+#   # Note: If you are already a user of doorkeeper and have existing tokens
+#   # in your installation, they will be invalid without enabling the additional
+#   # setting `fallback_to_plain_secrets` below.
+#   #
+#   # hash_token_secrets
+#   # By default, token secrets will be hashed using the
+#   # +Doorkeeper::Hashing::SHA256+ strategy.
+#   #
+#   # If you wish to use another hashing implementation, you can override
+#   # this strategy as follows:
+#   #
+#   # hash_token_secrets using: '::Doorkeeper::Hashing::MyCustomHashImpl'
+#   #
+#   # Keep in mind that changing the hashing function will invalidate all existing
+#   # secrets, if there are any.
+
+#   # Hash application secrets before persisting them.
+#   #
+#   # hash_application_secrets
+#   #
+#   # By default, applications will be hashed
+#   # with the +Doorkeeper::SecretStoring::SHA256+ strategy.
+#   #
+#   # If you wish to use bcrypt for application secret hashing, uncomment
+#   # this line instead:
+#   #
+#   # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
+
+#   # When the above option is enabled, and a hashed token or secret is not found,
+#   # you can allow to fall back to another strategy. For users upgrading
+#   # doorkeeper and wishing to enable hashing, you will probably want to enable
+#   # the fallback to plain tokens.
+#   #
+#   # This will ensure that old access tokens and secrets
+#   # will remain valid even if the hashing above is enabled.
+#   #
+#   # fallback_to_plain_secrets
+
+#   # Issue access tokens with refresh token (disabled by default), you may also
+#   # pass a block which accepts `context` to customize when to give a refresh
+#   # token or not. Similar to +custom_access_token_expires_in+, `context` has
+#   # the following properties:
+#   #
+#   # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+#   # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+#   # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+#   #
+#   # use_refresh_token
+
+#   # Provide support for an owner to be assigned to each registered application (disabled by default)
+#   # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
+#   # a registered application
+#   # NOTE: you must also run the rails g doorkeeper:application_owner generator
+#   # to provide the necessary support
+#   #
+#   # enable_application_owner confirmation: false
+
+#   # Define access token scopes for your provider
+#   # For more information go to
+#   # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
+#   #
+#   # default_scopes  :public
+#   # optional_scopes :write, :update
+
+#   # Allows to restrict only certain scopes for grant_type.
+#   # By default, all the scopes will be available for all the grant types.
+#   #
+#   # Keys to this hash should be the name of grant_type and
+#   # values should be the array of scopes for that grant type.
+#   # Note: scopes should be from configured_scopes (i.e. default or optional)
+#   #
+#   # scopes_by_grant_type password: [:write], client_credentials: [:update]
+
+#   # Forbids creating/updating applications with arbitrary scopes that are
+#   # not in configuration, i.e. +default_scopes+ or +optional_scopes+.
+#   # (disabled by default)
+#   #
+#   # enforce_configured_scopes
+
+#   # Change the way client credentials are retrieved from the request object.
+#   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+#   # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+#   # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+#   # for more information on customization
+#   #
+#   # client_credentials :from_basic, :from_params
+
+#   # Change the way access token is authenticated from the request object.
+#   # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+#   # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+#   # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+#   # for more information on customization
+#   #
+#   # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+#   # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+#   # by default in non-development environments). OAuth2 delegates security in
+#   # communication to the HTTPS protocol so it is wise to keep this enabled.
+#   #
+#   # Callable objects such as proc, lambda, block or any object that responds to
+#   # #call can be used in order to allow conditional checks (to allow non-SSL
+#   # redirects to localhost for example).
+#   #
+#   # force_ssl_in_redirect_uri !Rails.env.development?
+#   #
+#   # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+
+#   # Specify what redirect URI's you want to block during Application creation.
+#   # Any redirect URI is whitelisted by default.
+#   #
+#   # You can use this option in order to forbid URI's with 'javascript' scheme
+#   # for example.
+#   #
+#   # forbid_redirect_uri { |uri| uri.scheme.to_s.downcase == 'javascript' }
+
+#   # Allows to set blank redirect URIs for Applications in case Doorkeeper configured
+#   # to use URI-less OAuth grant flows like Client Credentials or Resource Owner
+#   # Password Credentials. The option is on by default and checks configured grant
+#   # types, but you **need** to manually drop `NOT NULL` constraint from `redirect_uri`
+#   # column for `oauth_applications` database table.
+#   #
+#   # You can completely disable this feature with:
+#   #
+#   # allow_blank_redirect_uri false
+#   #
+#   # Or you can define your custom check:
+#   #
+#   # allow_blank_redirect_uri do |grant_flows, client|
+#   #   client.superapp?
+#   # end
+
+#   # Specify how authorization errors should be handled.
+#   # By default, doorkeeper renders json errors when access token
+#   # is invalid, expired, revoked or has invalid scopes.
+#   #
+#   # If you want to render error response yourself (i.e. rescue exceptions),
+#   # set +handle_auth_errors+ to `:raise` and rescue Doorkeeper::Errors::InvalidToken
+#   # or following specific errors:
+#   #
+#   #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
+#   #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
+#   #
+#   # handle_auth_errors :raise
+
+#   # Customize token introspection response.
+#   # Allows to add your own fields to default one that are required by the OAuth spec
+#   # for the introspection response. It could be `sub`, `aud` and so on.
+#   # This configuration option can be a proc, lambda or any Ruby object responds
+#   # to `.call` method and result of it's invocation must be a Hash.
+#   #
+#   # custom_introspection_response do |token, context|
+#   #   {
+#   #     "sub": "Z5O3upPC88QrAjx00dis",
+#   #     "aud": "https://protected.example.net/resource",
+#   #     "username": User.find(token.resource_owner_id).username
+#   #   }
+#   # end
+#   #
+#   # or
+#   #
+#   # custom_introspection_response CustomIntrospectionResponder
+
+#   # Specify what grant flows are enabled in array of Strings. The valid
+#   # strings and the flows they enable are:
+#   #
+#   # "authorization_code" => Authorization Code Grant Flow
+#   # "implicit"           => Implicit Grant Flow
+#   # "password"           => Resource Owner Password Credentials Grant Flow
+#   # "client_credentials" => Client Credentials Grant Flow
+#   #
+#   # If not specified, Doorkeeper enables authorization_code and
+#   # client_credentials.
+#   #
+#   # implicit and password grant flows have risks that you should understand
+#   # before enabling:
+#   #   http://tools.ietf.org/html/rfc6819#section-4.4.2
+#   #   http://tools.ietf.org/html/rfc6819#section-4.4.3
+#   #
+#   # grant_flows %w[authorization_code client_credentials]
+
+#   # Allows to customize OAuth grant flows that +each+ application support.
+#   # You can configure a custom block (or use a class respond to `#call`) that must
+#   # return `true` in case Application instance supports requested OAuth grant flow
+#   # during the authorization request to the server. This configuration +doesn't+
+#   # set flows per application, it only allows to check if application supports
+#   # specific grant flow.
+#   #
+#   # For example you can add an additional database column to `oauth_applications` table,
+#   # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
+#   # be used with this application there. Then when authorization requested Doorkeeper
+#   # will call this block to check if specific Application (passed with client_id and/or
+#   # client_secret) is allowed to perform the request for the specific grant type
+#   # (authorization, password, client_credentials, etc).
+#   #
+#   # Example of the block:
+#   #
+#   #   ->(flow, client) { client.grant_flows.include?(flow) }
+#   #
+#   # In case this option invocation result is `false`, Doorkeeper server returns
+#   # :unauthorized_client error and stops the request.
+#   #
+#   # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
+#   # @return [Boolean] `true` if allow or `false` if forbid the request
+#   #
+#   # allow_grant_flow_for_client do |grant_flow, client|
+#   #   # `grant_flows` is an Array column with grant
+#   #   # flows that application supports
+#   #
+#   #   client.grant_flows.include?(grant_flow)
+#   # end
+
+#   # If you need arbitrary Resource Owner-Client authorization you can enable this option
+#   # and implement the check your need. Config option must respond to #call and return
+#   # true in case resource owner authorized for the specific application or false in other
+#   # cases.
+#   #
+#   # Be default all Resource Owners are authorized to any Client (application).
+#   #
+#   # authorize_resource_owner_for_client do |client, resource_owner|
+#   #   resource_owner.admin? || client.owners_whitelist.include?(resource_owner)
+#   # end
+
+#   # Hook into the strategies' request & response life-cycle in case your
+#   # application needs advanced customization or logging:
+#   #
+#   # before_successful_strategy_response do |request|
+#   #   puts "BEFORE HOOK FIRED! #{request}"
+#   # end
+#   #
+#   # after_successful_strategy_response do |request, response|
+#   #   puts "AFTER HOOK FIRED! #{request}, #{response}"
+#   # end
+
+#   # Hook into Authorization flow in order to implement Single Sign Out
+#   # or add any other functionality. Inside the block you have an access
+#   # to `controller` (authorizations controller instance) and `context`
+#   # (Doorkeeper::OAuth::Hooks::Context instance) which provides pre auth
+#   # or auth objects with issued token based on hook type (before or after).
+#   #
+#   # before_successful_authorization do |controller, context|
+#   #   Rails.logger.info(controller.request.params.inspect)
+#   #
+#   #   Rails.logger.info(context.pre_auth.inspect)
+#   # end
+#   #
+#   # after_successful_authorization do |controller, context|
+#   #   controller.session[:logout_urls] <<
+#   #     Doorkeeper::Application
+#   #       .find_by(controller.request.params.slice(:redirect_uri))
+#   #       .logout_uri
+#   #
+#   #   Rails.logger.info(context.auth.inspect)
+#   #   Rails.logger.info(context.issued_token)
+#   # end
+
+#   # Under some circumstances you might want to have applications auto-approved,
+#   # so that the user skips the authorization step.
+#   # For example if dealing with a trusted application.
+#   #
+#   # skip_authorization do |resource_owner, client|
+#   #   client.superapp? or resource_owner.admin?
+#   # end
+
+#   # Configure custom constraints for the Token Introspection request.
+#   # By default this configuration option allows to introspect a token by another
+#   # token of the same application, OR to introspect the token that belongs to
+#   # authorized client (from authenticated client) OR when token doesn't
+#   # belong to any client (public token). Otherwise requester has no access to the
+#   # introspection and it will return response as stated in the RFC.
+#   #
+#   # Block arguments:
+#   #
+#   # @param token [Doorkeeper::AccessToken]
+#   #   token to be introspected
+#   #
+#   # @param authorized_client [Doorkeeper::Application]
+#   #   authorized client (if request is authorized using Basic auth with
+#   #   Client Credentials for example)
+#   #
+#   # @param authorized_token [Doorkeeper::AccessToken]
+#   #   Bearer token used to authorize the request
+#   #
+#   # In case the block returns `nil` or `false` introspection responses with 401 status code
+#   # when using authorized token to introspect, or you'll get 200 with { "active": false } body
+#   # when using authorized client to introspect as stated in the
+#   # RFC 7662 section 2.2. Introspection Response.
+#   #
+#   # Using with caution:
+#   # Keep in mind that these three parameters pass to block can be nil as following case:
+#   #  `authorized_client` is nil if and only if `authorized_token` is present, and vice versa.
+#   #  `token` will be nil if and only if `authorized_token` is present.
+#   # So remember to use `&` or check if it is present before calling method on
+#   # them to make sure you doesn't get NoMethodError exception.
+#   #
+#   # You can define your custom check:
+#   #
+#   # allow_token_introspection do |token, authorized_client, authorized_token|
+#   #   if authorized_token
+#   #     # customize: require `introspection` scope
+#   #     authorized_token.application == token&.application ||
+#   #       authorized_token.scopes.include?("introspection")
+#   #   elsif token.application
+#   #     # `protected_resource` is a new database boolean column, for example
+#   #     authorized_client == token.application || authorized_client.protected_resource?
+#   #   else
+#   #     # public token (when token.application is nil, token doesn't belong to any application)
+#   #     true
+#   #   end
+#   # end
+#   #
+#   # Or you can completely disable any token introspection:
+#   #
+#   # allow_token_introspection false
+#   #
+#   # If you need to block the request at all, then configure your routes.rb or web-server
+#   # like nginx to forbid the request.
+
+#   # WWW-Authenticate Realm (default: "Doorkeeper").
+#   #
+#   # realm "Doorkeeper"
+# end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,146 @@
+en:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: 'Name'
+        redirect_uri: 'Redirect URI'
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              unspecified_scheme: 'must specify a scheme.'
+              relative_uri: 'must be an absolute URI.'
+              secured_uri: 'must be an HTTPS/SSL URI.'
+              forbidden_uri: 'is forbidden by the server.'
+            scopes:
+              not_match_configured: "doesn't match configured on the server."
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: 'Are you sure?'
+      buttons:
+        edit: 'Edit'
+        destroy: 'Destroy'
+        submit: 'Submit'
+        cancel: 'Cancel'
+        authorize: 'Authorize'
+      form:
+        error: 'Whoops! Check your form for possible errors'
+      help:
+        confidential: 'Application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are considered non-confidential.'
+        redirect_uri: 'Use one line per URI'
+        blank_redirect_uri: "Leave it blank if you configured your provider to use Client Credentials, Resource Owner Password Credentials or any other grant type that doesn't require redirect URI."
+        scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
+      edit:
+        title: 'Edit application'
+      index:
+        title: 'Your applications'
+        new: 'New Application'
+        name: 'Name'
+        callback_url: 'Callback URL'
+        confidential: 'Confidential?'
+        actions: 'Actions'
+        confidentiality:
+          'yes': 'Yes'
+          'no': 'No'
+      new:
+        title: 'New Application'
+      show:
+        title: 'Application: %{name}'
+        application_id: 'UID'
+        secret: 'Secret'
+        secret_hashed: 'Secret hashed'
+        scopes: 'Scopes'
+        confidential: 'Confidential'
+        callback_urls: 'Callback urls'
+        actions: 'Actions'
+        not_defined: 'Not defined'
+
+    authorizations:
+      buttons:
+        authorize: 'Authorize'
+        deny: 'Deny'
+      error:
+        title: 'An error has occurred'
+      new:
+        title: 'Authorization required'
+        prompt: 'Authorize %{client_name} to use your account?'
+        able_to: 'This application will be able to'
+      show:
+        title: 'Authorization code'
+
+    authorized_applications:
+      confirmations:
+        revoke: 'Are you sure?'
+      buttons:
+        revoke: 'Revoke'
+      index:
+        title: 'Your authorized applications'
+        application: 'Application'
+        created_at: 'Created At'
+        date_format: '%Y-%m-%d %H:%M:%S'
+
+    pre_authorization:
+      status: 'Pre-authorization'
+
+    errors:
+      messages:
+        # Common error messages
+        invalid_request:
+          unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+          missing_param: 'Missing required parameter: %{value}.'
+          not_support_pkce: 'Invalid code_verifier parameter. Server does not support pkce.'
+          request_not_authorized: 'Request need to be authorized. Required parameter for authorizing request is missing or invalid.'
+        invalid_redirect_uri: "The requested redirect uri is malformed or doesn't match client redirect URI."
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        invalid_code_challenge_method: 'The code challenge method must be plain or S256.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        # Configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured.'
+        admin_authenticator_not_configured: 'Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+        revoke:
+          unauthorized: "You are not authorized to revoke this token"
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'
+
+    layouts:
+      admin:
+        title: 'Doorkeeper'
+        nav:
+          oauth2_provider: 'OAuth2 Provider'
+          applications: 'Applications'
+          home: 'Home'
+      application:
+        title: 'OAuth authorization required'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :taxonomies, only: [:index]
+      get "me", to: "me#show"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   
-  use_doorkeeper
   root "organisations#index"
 
+  use_doorkeeper
   devise_for :users, :controllers => { registrations: 'registrations' }
   devise_scope :user do
     get "login", to: "devise/sessions#new"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   
+  use_doorkeeper
   root "organisations#index"
 
   devise_for :users, :controllers => { registrations: 'registrations' }

--- a/db/migrate/20201001081939_create_doorkeeper_tables.rb
+++ b/db/migrate/20201001081939_create_doorkeeper_tables.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+class CreateDoorkeeperTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,    null: false
+      t.string  :uid,     null: false
+      t.string  :secret,  null: false
+
+      # Remove `null: false` if you are planning to use grant flows
+      # that doesn't require redirect URI to be used during authorization
+      # like Client Credentials flow or Resource Owner Password.
+      t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
+      t.boolean :confidential, null: false, default: true
+      t.timestamps             null: false
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.references :resource_owner,  null: false
+      t.references :application,     null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+      t.string   :scopes,            null: false, default: ''
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+    add_foreign_key(
+      :oauth_access_grants,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    create_table :oauth_access_tokens do |t|
+      t.references :resource_owner, index: true
+
+      # Remove `null: false` if you are planning to use Password
+      # Credentials Grant flow that doesn't require an application.
+      t.references :application,    null: false
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text :token, null: false
+      t.string :token, null: false
+
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.datetime :revoked_at
+      t.datetime :created_at, null: false
+      t.string   :scopes
+
+      # The authorization server MAY issue a new refresh token, in which case
+      # *the client MUST discard the old refresh token* and replace it with the
+      # new refresh token. The authorization server MAY revoke the old
+      # refresh token after issuing a new refresh token to the client.
+      # @see https://tools.ietf.org/html/rfc6749#section-6
+      #
+      # Doorkeeper implementation: if there is a `previous_refresh_token` column,
+      # refresh tokens will be revoked after a related access token is used.
+      # If there is no `previous_refresh_token` column, previous tokens are
+      # revoked as soon as a new access token is created.
+      #
+      # Comment out this line if you want refresh tokens to be instantly
+      # revoked after use.
+      t.string   :previous_refresh_token, null: false, default: ""
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+    add_index :oauth_access_tokens, :refresh_token, unique: true
+    add_foreign_key(
+      :oauth_access_tokens,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    # Uncomment below to ensure a valid reference to the resource owner's table
+    # add_foreign_key :oauth_access_grants, <model>, column: :resource_owner_id
+    # add_foreign_key :oauth_access_tokens, <model>, column: :resource_owner_id
+  end
+end

--- a/db/migrate/20201001083411_add_foreign_keys_to_oauth_tables.rb
+++ b/db/migrate/20201001083411_add_foreign_keys_to_oauth_tables.rb
@@ -1,0 +1,6 @@
+class AddForeignKeysToOauthTables < ActiveRecord::Migration[6.0]
+  def change
+    add_foreign_key :oauth_access_grants, :users, column: :resource_owner_id
+    add_foreign_key :oauth_access_tokens, :users, column: :resource_owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_01_081939) do
+ActiveRecord::Schema.define(version: 2020_10_01_083411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -394,7 +394,9 @@ ActiveRecord::Schema.define(version: 2020_10_01_081939) do
   add_foreign_key "notes", "services"
   add_foreign_key "notes", "users"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "regular_schedules", "services"
   add_foreign_key "service_meta", "services"
   add_foreign_key "services", "ofsted_items"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_28_124150) do
+ActiveRecord::Schema.define(version: 2020_10_01_081939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -109,6 +109,48 @@ ActiveRecord::Schema.define(version: 2020_09_28_124150) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["service_id"], name: "index_notes_on_service_id"
     t.index ["user_id"], name: "index_notes_on_user_id"
+  end
+
+  create_table "oauth_access_grants", force: :cascade do |t|
+    t.bigint "resource_owner_id", null: false
+    t.bigint "application_id", null: false
+    t.string "token", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.datetime "created_at", null: false
+    t.datetime "revoked_at"
+    t.string "scopes", default: "", null: false
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+  end
+
+  create_table "oauth_access_tokens", force: :cascade do |t|
+    t.bigint "resource_owner_id"
+    t.bigint "application_id", null: false
+    t.string "token", null: false
+    t.string "refresh_token"
+    t.integer "expires_in"
+    t.datetime "revoked_at"
+    t.datetime "created_at", null: false
+    t.string "scopes"
+    t.string "previous_refresh_token", default: "", null: false
+    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+  end
+
+  create_table "oauth_applications", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "uid", null: false
+    t.string "secret", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.boolean "confidential", default: true, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
   create_table "ofsted_items", force: :cascade do |t|
@@ -351,6 +393,8 @@ ActiveRecord::Schema.define(version: 2020_09_28_124150) do
   add_foreign_key "local_offers", "services"
   add_foreign_key "notes", "services"
   add_foreign_key "notes", "users"
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "regular_schedules", "services"
   add_foreign_key "service_meta", "services"
   add_foreign_key "services", "ofsted_items"


### PR DESCRIPTION
implement doorkeeper to turn outpost into an oauth provider

you should now be able to

- logged in as a user who can manage other users, go to /oauth/applications to register an app
- in a consumer app, go through a complete oauth flow to get a grant and a token
- call the /me outpost api endpoint with a valid token and get some info about the auth’ed user