### PR TITLE
Feature/send needs

### DIFF
--- a/app/models/send_need.rb
+++ b/app/models/send_need.rb
@@ -1,0 +1,7 @@
+class SendNeed < ApplicationRecord
+    has_and_belongs_to_many :services
+
+    def display_name
+        name.humanize
+    end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -16,6 +16,8 @@ class Service < ApplicationRecord
 
   belongs_to :ofsted_item, required: false
 
+  has_and_belongs_to_many :send_needs
+
   has_many :snapshots
 
   has_many :links
@@ -247,6 +249,7 @@ class Service < ApplicationRecord
       :meta => {},
       :contacts => {},
       :local_offer => {},
+      :send_needs => {},
       :cost_options => {},
       :regular_schedules => {}
     }

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -29,6 +29,7 @@ class IndexedServicesSerializer < ActiveModel::Serializer
   has_many :cost_options
   # has_many :meta
   has_many :links
+  has_many :send_needs
 
   has_one :local_offer, unless: -> { object.local_offer&.marked_for_destruction? }
 

--- a/app/serializers/send_need_serializer.rb
+++ b/app/serializers/send_need_serializer.rb
@@ -1,0 +1,3 @@
+class SendNeedSerializer < ActiveModel::Serializer
+    attribute :name
+end

--- a/app/views/admin/services/editors/_local-offer.html.erb
+++ b/app/views/admin/services/editors/_local-offer.html.erb
@@ -12,5 +12,15 @@
         <%= render "admin/services/editors/local-offer-fields", l: l %>
     <% end %>
 
+    <fieldset class="field-group field-group--two-cols field-group--no-top-margin margin-bottom">
+        <legend class="field-group__legend">Which SEND needs can you support?</legend>
+        <%= l.collection_check_boxes( :send_need_ids, SendNeed.all, :id, :display_name) do |c| %>
+            <div class="field checkbox checkbox--small">
+                <%= c.check_box class: "checkbox__input" %>
+                <%= c.label class: "checkbox__label" %>
+            </div>
+        <% end %>
+    </fieldset>
+
 </div>
 <% end %>

--- a/db/migrate/20201020113125_add_send_needs.rb
+++ b/db/migrate/20201020113125_add_send_needs.rb
@@ -1,0 +1,11 @@
+class AddSendNeeds < ActiveRecord::Migration[6.0]
+  def change
+    create_table :send_needs do |t|
+      t.string :name
+
+      t.timestamps
+    end
+
+    create_join_table(:services, :send_needs)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_15_153808) do
+ActiveRecord::Schema.define(version: 2020_10_20_113125) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -246,6 +246,17 @@ ActiveRecord::Schema.define(version: 2020_10_15_153808) do
     t.string "postcode"
     t.string "ward"
     t.string "family_centre"
+  end
+
+  create_table "send_needs", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "send_needs_services", id: false, force: :cascade do |t|
+    t.bigint "service_id", null: false
+    t.bigint "send_need_id", null: false
   end
 
   create_table "service_at_locations", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -163,14 +163,15 @@ bucks_csv.each.with_index do |row, line|
 
   unless row['lo_needs_level'] == nil
     send_needs = row['lo_needs_level'].split("\n")
+
     send_needs.each do |send_need|
-      send_need_taxonomy_path = ["SEND needs", send_need]
-      taxonomy = Taxonomy.create_with(skip_mongo_callbacks: true).find_or_create_by_path(send_need_taxonomy_path)
-      service.taxonomies |= [taxonomy]
+      service.send_needs << SendNeed.find_or_initialize_by({name: send_need.downcase.capitalize})
     end
+
     if send_needs.include? "All Needs Met"
-      service.taxonomies |= Taxonomy.find_by_path("SEND needs").children
+      service.send_needs << SendNeed.all
     end
+
   end
 
   unless row['familychannel'] == nil

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -273,9 +273,9 @@ all_needs_met_taxonomy.destroy!
 
 puts "Took #{(end_time - start_time)/60} minutes"
 
-# lock top-level taxa
-Taxonomy.roots.each do |t|
-  t.locked = true
-  t.skip_mongo_callbacks = true
-  t.save
-end
+# # lock top-level taxa
+# Taxonomy.roots.each do |t|
+#   t.locked = true
+#   t.skip_mongo_callbacks = true
+#   t.save
+# end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -135,14 +135,14 @@ bucks_csv.each.with_index do |row, line|
     end
   end
 
-  unless row['coronavirus_status'] == nil
-    coronavirus_statuses = row['coronavirus_status'].split("\n")
-    coronavirus_statuses.each do |coronavirus_status|
-      coronavirus_status_path = ["Coronavirus status", coronavirus_status]
-      taxonomy = Taxonomy.create_with(skip_mongo_callbacks: true).find_or_create_by_path(coronavirus_status_path)
-      service.taxonomies |= [taxonomy]
-    end
-  end
+  # unless row['coronavirus_status'] == nil
+  #   coronavirus_statuses = row['coronavirus_status'].split("\n")
+  #   coronavirus_statuses.each do |coronavirus_status|
+  #     coronavirus_status_path = ["Coronavirus status", coronavirus_status]
+  #     taxonomy = Taxonomy.create_with(skip_mongo_callbacks: true).find_or_create_by_path(coronavirus_status_path)
+  #     service.taxonomies |= [taxonomy]
+  #   end
+  # end
 
   unless row['lo_age_bands'] == nil
     age_groups = row['lo_age_bands'].split("\n")

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -273,9 +273,9 @@ all_needs_met_taxonomy.destroy!
 
 puts "Took #{(end_time - start_time)/60} minutes"
 
-# # lock top-level taxa
-# Taxonomy.roots.each do |t|
-#   t.locked = true
-#   t.skip_mongo_callbacks = true
-#   t.save
-# end
+# lock top-level taxa
+Taxonomy.roots.each do |t|
+  t.locked = true
+  t.skip_mongo_callbacks = true
+  t.save
+end

--- a/spec/models/send_need_spec.rb
+++ b/spec/models/send_need_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SendNeed, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
- add a new model and join table for send needs
- add a basic interface to the service local offer editor to select send needs with checkboxes
- update seed file to populate send needs properly and stop populating taxonomies we no longer need


STILL TO DO:

- get rid of the current top level taxa (“Category” “SEND Needs” “Coronavirus status” etc) and make them equal the top categories (advice and support, etc)