### PR TITLE
Tweaks/ofsted

### DIFF
--- a/app/assets/stylesheets/bucks-fis-design-library/_collapsibles.scss
+++ b/app/assets/stylesheets/bucks-fis-design-library/_collapsibles.scss
@@ -30,13 +30,13 @@
             background-size: contain;
             background-position: center;
             background-repeat: no-repeat;
-            background-image: url(asset_path("up-arrow.svg"));
+            background-image: url(asset_path("down-arrow.svg"));
         }
 
         &[aria-expanded=false]{
             margin-bottom: 0px;
             &:after{
-                background-image: url(asset_path("down-arrow.svg"));
+                background-image: url(asset_path("up-arrow.svg"));
     
             }
         }

--- a/app/assets/stylesheets/bucks-fis-design-library/_todo.scss
+++ b/app/assets/stylesheets/bucks-fis-design-library/_todo.scss
@@ -3,6 +3,12 @@
     margin: 0;
     padding: 0;
 
+    &__divider{
+        color: $grey3;
+        opacity: 0.5;
+        margin: 0px 7px;
+    }
+
     &__item{
         background: $pale;
         padding: 25px;

--- a/app/models/ofsted_item.rb
+++ b/app/models/ofsted_item.rb
@@ -94,6 +94,16 @@ class OfstedItem < ApplicationRecord
     end
   end
 
+  def unapproved_fields
+    changed_fields = []
+    versions.last.changeset.map do |key, value|
+      unless ignorable_fields.include?(key)
+        changed_fields << key.humanize
+      end
+    end
+    changed_fields
+  end
+
   # fields we don't care about for version history purposes
   def ignorable_fields
     ["status", "updated_at", "created_at", "discarded_at"]

--- a/app/models/ofsted_item.rb
+++ b/app/models/ofsted_item.rb
@@ -36,7 +36,7 @@ class OfstedItem < ApplicationRecord
     when /^name_/
       order("LOWER(ofsted_items.setting_name) #{direction} NULLS LAST")
     when /^created_at_/
-      order("registration_date #{direction}")
+      order("created_at #{direction}")
     else
       raise(ArgumentError, "Invalid sort option: #{sort_option.inspect}")
     end

--- a/app/views/admin/ofsted/_notices.html.erb
+++ b/app/views/admin/ofsted/_notices.html.erb
@@ -1,0 +1,26 @@
+<% unless @item.status %>
+    <div class="notice notice--pending">
+        <div class="notice__body">
+
+            <% if @item.status === "new" %>
+
+            <% elsif @item.status === "deleted"%>
+
+            <% else %>
+
+            <% end %>
+
+        </div>      
+    </div>
+
+<% else %>
+
+    <% if @item.discarded? %>
+        <div class="notice notice--cross">
+            <div class="notice__body">
+                <p>This item is no longer present in the Ofsted feed.</p>
+            </div>
+        </div>
+    <% end %>
+
+<% end %>

--- a/app/views/admin/ofsted/_notices.html.erb
+++ b/app/views/admin/ofsted/_notices.html.erb
@@ -1,12 +1,31 @@
-<% unless @item.status %>
+<% if @item.status %>
     <div class="notice notice--pending">
         <div class="notice__body">
 
             <% if @item.status === "new" %>
 
+                <% if @item.registration_status === "Proposed" %>
+                  <p>This is a new proposed provider.</p>
+                <% else %>
+                  <p>This is a new provider.</p>
+                <% end %>
+
+                <%= link_to "Acknowledge", admin_ofsted_dismiss_path(@item), method: "put", class: "notice__action" %>
+
             <% elsif @item.status === "deleted"%>
+                <p>This item is no longer present in the Ofsted feed.</p>
+
+                <%= link_to "Acknowledge", admin_ofsted_dismiss_path(@item), method: "put", class: "notice__action" %>
+                <span class="notice__divider">|</span>
+                <%= link_to "Compare versions", admin_ofsted_versions_path(@item), class: "notice__action" %>
 
             <% else %>
+
+                <p>Ofsted has made changes to <strong><%= @item.unapproved_fields.join(", ") %></strong>.</p>
+
+                <%= link_to "Acknowledge", admin_ofsted_dismiss_path(@item), method: "put", class: "notice__action" %>
+                <span class="notice__divider">|</span>
+                <%= link_to "Compare versions", admin_ofsted_versions_path(@item), class: "notice__action" %>
 
             <% end %>
 

--- a/app/views/admin/ofsted/index.html.erb
+++ b/app/views/admin/ofsted/index.html.erb
@@ -27,7 +27,7 @@
                     <td><%= i.provider_name %></td>
                     <td><%= i.provision_type %></td>
                     <td><%= status_tag(i.registration_status) %></td>
-                    <td><%= short_time_ago_in_words(i.last_change_date).humanize + " ago"  if i.last_change_date %></td>
+                    <td><%= short_time_ago_in_words(i.updated_at).humanize %> ago</td>
                     <td>
                       <%= format_if_date(i.registration_date) %>
                     </td>

--- a/app/views/admin/ofsted/pending.html.erb
+++ b/app/views/admin/ofsted/pending.html.erb
@@ -16,7 +16,11 @@
         </div>
         <% if s.status === "new" %>
             <div class="todo-status todo-status--new">
-                <strong>New provider</strong>
+                <% if s.registration_status === "Proposed" %>
+                  <strong>New proposed provider</strong>
+                <% else %>
+                  <strong>New provider</strong>
+                <% end %>
             </div>
         <% elsif s.status === "deleted"%>
             <div class="todo-status todo-status--deleted">
@@ -28,7 +32,7 @@
             <p><%= s.versions.last.changeset.map{ |key, value| key.humanize }.join(", ") %></p>
             </div>
         <% end %>
-        <%= link_to "Dismiss", admin_ofsted_dismiss_path(s), method: "put", class: "button" %>
+        <%= link_to "Acknowledge", admin_ofsted_dismiss_path(s), method: "put", class: "button" %>
       </li>
     <% end %>
   </ul>

--- a/app/views/admin/ofsted/pending.html.erb
+++ b/app/views/admin/ofsted/pending.html.erb
@@ -11,6 +11,8 @@
           <h2><%= link_to s.setting_name.truncate(25), admin_ofsted_path(s) %></h2>
           <p>
             <%= time_ago_in_words(s.updated_at).humanize %> ago
+            <span class="todo-list__divider">|</span>
+            <%= link_to "Compare versions", admin_ofsted_versions_path(s) %>
           </p>
         </div>
         <% if s.status === "new" %>

--- a/app/views/admin/ofsted/pending.html.erb
+++ b/app/views/admin/ofsted/pending.html.erb
@@ -3,7 +3,6 @@
     <%= render "shortcut-nav" %>
 <% end %>
 
-
 <% if @requests.present? %>
   <ul class="todo-list">
     <% @requests.each do |s| %>
@@ -29,7 +28,7 @@
         <% else %>
             <div class="todo-status">
             <strong>Changed</strong>
-            <p><%= s.versions.last.changeset.map{ |key, value| key.humanize }.join(", ") %></p>
+            <p><%= s.unapproved_fields.join(", ") %></p>
             </div>
         <% end %>
         <%= link_to "Acknowledge", admin_ofsted_dismiss_path(s), method: "put", class: "button" %>

--- a/app/views/admin/ofsted/pending.html.erb
+++ b/app/views/admin/ofsted/pending.html.erb
@@ -8,7 +8,7 @@
     <% @requests.each do |s| %>
       <li class="todo-list__item">
         <div>
-          <h2><%= link_to s.setting_name.truncate(25), admin_ofsted_path(s) %></h2>
+          <h2><%= link_to s.display_name.truncate(25), admin_ofsted_path(s) %></h2>
           <p>
             <%= time_ago_in_words(s.updated_at).humanize %> ago
             <span class="todo-list__divider">|</span>

--- a/app/views/admin/ofsted/show.html.erb
+++ b/app/views/admin/ofsted/show.html.erb
@@ -1,13 +1,5 @@
 <% content_for :header do %> 
-
-    <% if @item.discarded? %>
-      <div class="notice notice--cross">
-        <div class="notice__body">
-          <p>This item is no longer present in the Ofsted feed.</p>
-        </div>
-      </div>
-    <% end %>
-
+    <%= render "notices" %>
     <%= render "shared/dynamic-back-link", text: "Go back", path: admin_ofsted_index_path %>
     <div class="page-header__actions">
       <h1 class="page-header__title two-thirds"><%= @item.display_name %></h1>
@@ -34,6 +26,7 @@
           <%= render "admin/ofsted/field", label: "Reference number", value: @item.reference_number %>
           <%= render "admin/ofsted/field", label: "Status", value: @item.registration_status %>
           <%= render "admin/ofsted/field", label: "Registration date", value: format_if_date(@item.registration_date) %>
+          <%= render "admin/ofsted/field", label: "Last changed by Ofsted", value: format_if_date(@item.lastupdated) %>
         </div>
 
         <div class="field-group field-group--two-cols">
@@ -48,7 +41,7 @@
               <p class="read-only-field__label">Ofsted report</p>
               <p class="read-only-field__value">
                   <% if @item.link_to_ofsted_report.present? %>
-                      <%= link_to "See latest report", @item.link_to_ofsted_report %>
+                      <%= link_to "See latest report", @item.link_to_ofsted_report, target: "blank" %>
                   <% else %>
                       —
                   <% end %>
@@ -115,75 +108,84 @@
         </div>
       <% end %>
 
-        <%= render "shared/collapsible", name: "Everything else", id: "ofsted-everything-else" do %>
-            <div class="tabs">
-                <ul class="tabs__nav">
-                  <li class="tabs__nav-item">
-                    <a href="#childcare-period" class="tabs__nav-link">Childcare period</a>
-                  </li>
-                  <li class="tabs__nav-item">
-                    <a href="#registration-history" class="tabs__nav-link">Registration history</a>
-                  </li>
-                  <li class="tabs__nav-item">
-                    <a href="#childcare-services-register" class="tabs__nav-link">Childcare services register</a>
-                  </li>
-                  <li class="tabs__nav-item">
-                    <a href="#certificate-conditions" class="tabs__nav-link">Certificate conditions</a>
-                  </li>
-                  <li class="tabs__nav-item">
-                    <a href="#childcare-ages" class="tabs__nav-link">Childcare ages</a>
-                  </li>
-                  <li class="tabs__nav-item">
-                    <a href="#inspections" class="tabs__nav-link">Inspections</a>
-                  </li>
-                  <li class="tabs__nav-item">
-                    <a href="#notice-history" class="tabs__nav-link">Notice history</a>
-                  </li>
-                  <li class="tabs__nav-item">
-                    <a href="#welfare-notice-history" class="tabs__nav-link">Welfare notice history</a>
-                  </li>
-                  <li class="tabs__nav-item">
-                    <a href="#links-registrations" class="tabs__nav-link">Linked registrations</a>
-                  </li>
-                </ul>
-                <div class="tabs__panel" id="childcare-period">
-                  <% if @item.childcare_period.any? %>
-                    <ul class="big-list">
-                      <% @item.childcare_period.each do |r| %>
-                        <li class="big-list__item"><%= r %></li>
-                      <% end %>
-                    </ul>
-                  <% else %>
-                    <p class="no-results">Nothing to show</p>
-                  <% end %>
-                </div>
-                <div class="tabs__panel" id="registration-history">
-                  <%= render "admin/ofsted/mini-table", t: @item.registration_status_history %>
-                </div>
-                <div class="tabs__panel" id="childcare-services-register">
-                  <%= render "admin/ofsted/mini-table", t: @item.child_services_register %>
-                </div>
-                <div class="tabs__panel" id="certificate-conditions">
-                  <%= render "admin/ofsted/mini-table", t: @item.certificate_condition %>
-                </div>
-                <div class="tabs__panel" id="childcare-ages">
-                  <%= render "admin/ofsted/mini-table-childcare-age", t: @item.childcare_age %>
-                </div>
-                <div class="tabs__panel" id="inspections">
-                  <%= render "admin/ofsted/mini-table", t: @item.inspection %>
-                </div>
-                <div class="tabs__panel" id="notice-history">
-                  <%= render "admin/ofsted/mini-table", t: @item.notice_history %>
-                </div>
-                <div class="tabs__panel" id="welfare-notice-history">
-                  <%= render "admin/ofsted/mini-table-welfare-notice-history", t: @item.welfare_notice_history %>
-                </div>
-                <div class="tabs__panel" id="links-registrations">
-                  <%= render "admin/ofsted/mini-table", t: @item.linked_registration %>
-                </div>
-            </div>
+      <%= render "shared/collapsible", name: "Registration history", id: "ofsted-registration-history" do %>
+          <div class="tabs">
+              <ul class="tabs__nav">
+                <li class="tabs__nav-item">
+                  <a href="#childcare-period" class="tabs__nav-link">Childcare period</a>
+                </li>
+                <li class="tabs__nav-item">
+                  <a href="#registration-history" class="tabs__nav-link">Registration history</a>
+                </li>
+                <li class="tabs__nav-item">
+                  <a href="#childcare-services-register" class="tabs__nav-link">Childcare services register</a>
+                </li>
+                <li class="tabs__nav-item">
+                  <a href="#certificate-conditions" class="tabs__nav-link">Certificate conditions</a>
+                </li>
+                <li class="tabs__nav-item">
+                  <a href="#childcare-ages" class="tabs__nav-link">Childcare ages</a>
+                </li>
+                <li class="tabs__nav-item">
+                  <a href="#inspections" class="tabs__nav-link">Inspections</a>
+                </li>
+              </ul>
+              <div class="tabs__panel" id="childcare-period">
+                <% if @item.childcare_period.any? %>
+                  <ul class="big-list">
+                    <% @item.childcare_period.each do |r| %>
+                      <li class="big-list__item"><%= r %></li>
+                    <% end %>
+                  </ul>
+                <% else %>
+                  <p class="no-results">Nothing to show</p>
+                <% end %>
+              </div>
+              <div class="tabs__panel" id="registration-history">
+                <%= render "admin/ofsted/mini-table", t: @item.registration_status_history %>
+              </div>
+              <div class="tabs__panel" id="childcare-services-register">
+                <%= render "admin/ofsted/mini-table", t: @item.child_services_register %>
+              </div>
+              <div class="tabs__panel" id="certificate-conditions">
+                <%= render "admin/ofsted/mini-table", t: @item.certificate_condition %>
+              </div>
+              <div class="tabs__panel" id="childcare-ages">
+                <%= render "admin/ofsted/mini-table-childcare-age", t: @item.childcare_age %>
+              </div>
+              <div class="tabs__panel" id="inspections">
+                <%= render "admin/ofsted/mini-table", t: @item.inspection %>
+              </div>
+          </div>
 
-        <% end %>
+      <% end %>
+
+      <%= render "shared/collapsible", name: "Notice history", id: "ofsted-notice-history" do %>
+          <div class="tabs">
+              <ul class="tabs__nav">
+                <li class="tabs__nav-item">
+                  <a href="#notice-history" class="tabs__nav-link">Notice history</a>
+                </li>
+                <li class="tabs__nav-item">
+                  <a href="#welfare-notice-history" class="tabs__nav-link">Welfare notice history</a>
+                </li>
+                <li class="tabs__nav-item">
+                  <a href="#links-registrations" class="tabs__nav-link">Linked registrations</a>
+                </li>
+              </ul>
+              <div class="tabs__panel" id="notice-history">
+                <%= render "admin/ofsted/mini-table", t: @item.notice_history %>
+              </div>
+              <div class="tabs__panel" id="welfare-notice-history">
+                <%= render "admin/ofsted/mini-table-welfare-notice-history", t: @item.welfare_notice_history %>
+              </div>
+              <div class="tabs__panel" id="links-registrations">
+                <%= render "admin/ofsted/mini-table", t: @item.linked_registration %>
+              </div>
+          </div>
+
+      <% end %>
+
 
   </div>
   <aside class="with-sidebar__sidebar">

--- a/app/views/admin/ofsted/show.html.erb
+++ b/app/views/admin/ofsted/show.html.erb
@@ -70,7 +70,7 @@
               </p>
           </div>
 
-          <%= render "admin/ofsted/field", label: "Related RPPs", value: @item.related_rpps %>
+          <%# render "admin/ofsted/field", label: "Related RPPs", value: @item.related_rpps %>
         </div>
       <% end %>
 

--- a/app/views/admin/ofsted/show.html.erb
+++ b/app/views/admin/ofsted/show.html.erb
@@ -203,7 +203,7 @@
       <%= render "shared/version-tree", object: @item %>
     <% end %>
 
-    <%= render "shared/collapsible", name: "Other settings by this provider", id: "ofsted-other-settings" do %> 
+    <%= render "shared/collapsible", name: "Related settings", id: "ofsted-other-settings" do %> 
         <% if @related_items.present? %>
           <ul class="big-list">
             <% @related_items.each do |i| %>

--- a/app/views/admin/services/editors/_basics.html.erb
+++ b/app/views/admin/services/editors/_basics.html.erb
@@ -6,7 +6,7 @@
 
     <div class="field field--required <%= mark_unapproved_field("organisation_id") %>">
         <%= s.label :organisation_id, "Parent organisation", class: "field__label" %>
-        <%= s.collection_select( :organisation_id, Organisation.all, :id, :display_name, {selected: @service.organisation }, class: "field__input", data: {choices: true})%>
+        <%= s.collection_select( :organisation_id, Organisation.all, :id, :display_name, {selected: @service.organisation, include_blank: "" }, class: "field__input" )%>
     </div>
 
     <div class="field field--span-two-cols <%= mark_unapproved_field("description") %>" data-word-count="true">

--- a/lib/tasks/ofsted.rake
+++ b/lib/tasks/ofsted.rake
@@ -49,7 +49,6 @@ namespace :ofsted do
       ofsted_item = OfstedItem.where(reference_number: item["reference_number"]).first # Check if ofsted item already exists
 
       if ofsted_item
-
         ofsted_item.assign_attributes(ofsted_item_params(item)) # Prepare for update
 
         if ofsted_item.changed?
@@ -76,14 +75,14 @@ namespace :ofsted do
     end
 
     OfstedItem.all.each do |ofsted_item| # check for deleted
-      unless items.select { |item| item["reference_number"] == ofsted_item.reference_number }.present?
-        ofsted_item.status = "deleted"
-        ofsted_item.discarded_at = Time.now
-        if ofsted_item.save
-          puts "Set ofsted item status to deleted"
-        else
-          puts "Failed to update ofsted item"
-        end
+      next if items.select { |item| item["reference_number"] == ofsted_item.reference_number }.present? # Dont archive if still in feed
+      next if (ofsted_item.discarded_at != nil) && (ofsted_item.status == 'deleted') # Don't archive if already archived.
+      ofsted_item.status = "deleted"
+      ofsted_item.discarded_at = Time.now
+      if ofsted_item.save
+        puts "Set ofsted item status to deleted"
+      else
+        puts "Failed to update ofsted item"
       end
     end
 


### PR DESCRIPTION
- tweaked the pending screen to say “new proposed provider” if registration status === “Proposed”
- tweak pending screen buttons so they don’t say “dismiss” any more and include a "compare versions" link
- showed “last changed by ofsted” on the show screen
- fixed the recently updated filter and index table column to use internal updated_at rather than ofsted-supplied value
- ofsted report link opens in new tab
- hide “related rrps” field
- “other settings by this provider” -> “related settings”
- arrows on collapsibles reversed
- added a placeholder to organisation input
- need to add better notices to the admin/ofsted/show view, to mirror those that you see on the pending screen. already done this for services
- need to have updated at and similar ignorable fields invisible on the pending screen. thought we’d already done this. there’s an ignorable_fields method on the model to help