### PR TITLE
Feature/custom fields in api

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,4 +435,4 @@ RUBY VERSION
    ruby 2.6.0p0
 
 BUNDLED WITH
-   1.17.2
+   2.2.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,4 +435,4 @@ RUBY VERSION
    ruby 2.6.0p0
 
 BUNDLED WITH
-   2.2.4
+   1.17.2

--- a/app/controllers/admin/custom_field_sections_controller.rb
+++ b/app/controllers/admin/custom_field_sections_controller.rb
@@ -46,6 +46,7 @@ class Admin::CustomFieldSectionsController < Admin::BaseController
         :name,
         :hint,
         :public,
+        :api_public,
         :sort_order,
         custom_fields_attributes: [
           :id,

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -22,12 +22,21 @@ class IndexedServicesSerializer < ActiveModel::Serializer
     object.contacts.where(visible: true)
   end
 
+  has_many :meta do
+
+    object.meta.each do |m|
+      should_serialise = CustomField.find_by(key: object.meta.key)
+        .custom_field_section
+        .api_visible
+      m if should_serialise?
+    end
+  end
+
   belongs_to :organisation
 
   has_many :taxonomies
   has_many :regular_schedules
   has_many :cost_options
-  # has_many :meta
   has_many :links
   has_many :send_needs
 

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -23,12 +23,12 @@ class IndexedServicesSerializer < ActiveModel::Serializer
   end
 
   has_many :meta do
+    meta_to_serialise = []
     object.meta.each do |m|
-      should_serialise = CustomField.find_by(key: m.key)
-        .custom_field_section
-        .api_public
-      m if should_serialise
+      should_serialise = CustomField.find_by(key: m.key).custom_field_section.api_public
+      meta_to_serialise << m if should_serialise
     end
+    meta_to_serialise
   end
 
   belongs_to :organisation

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -25,7 +25,7 @@ class IndexedServicesSerializer < ActiveModel::Serializer
   has_many :meta do
     meta_to_serialise = []
     object.meta.each do |m|
-      should_serialise = CustomField.find_by(key: m.key).custom_field_section.api_public
+      should_serialise = CustomField.find_by(key: m.key)&.custom_field_section&.api_public
       meta_to_serialise << m if should_serialise
     end
     meta_to_serialise

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -24,10 +24,10 @@ class IndexedServicesSerializer < ActiveModel::Serializer
 
   has_many :meta do
     object.meta.each do |m|
-      should_serialise = CustomField.find_by(key: object.meta.key)
+      should_serialise = CustomField.find_by(key: m.key)
         .custom_field_section
-        .api_visible
-      m if should_serialise?
+        .api_public
+      m if should_serialise
     end
   end
 

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -23,7 +23,6 @@ class IndexedServicesSerializer < ActiveModel::Serializer
   end
 
   has_many :meta do
-
     object.meta.each do |m|
       should_serialise = CustomField.find_by(key: object.meta.key)
         .custom_field_section

--- a/app/serializers/local_offer_serializer.rb
+++ b/app/serializers/local_offer_serializer.rb
@@ -7,6 +7,6 @@ class LocalOfferSerializer < ActiveModel::Serializer
         object.survey_answers.map { |a| {
             question: object.questions.find{ |q| q[:id] === a["id"] }[:text],
             answer: a["answer"]
-        }}
+        }} if object.survey_answers
     end
 end

--- a/app/views/admin/custom_field_sections/_fields.html.erb
+++ b/app/views/admin/custom_field_sections/_fields.html.erb
@@ -19,7 +19,7 @@
 <div class="field checkbox">
     <%= f.check_box :public, class: "checkbox__input"%>
     <%= f.label :public, class: "checkbox__label" do %>
-        Make visible to community users?
+        Visible to community users?
         <button class="help-button help-button--small" type="button" data-tippy-content="If checked, all fields in this section can be seen and edited by residents.">What does this mean?</button>
     <% end %>
 </div>

--- a/app/views/admin/custom_field_sections/_fields.html.erb
+++ b/app/views/admin/custom_field_sections/_fields.html.erb
@@ -24,6 +24,14 @@
     <% end %>
 </div>
 
+<div class="field checkbox">
+    <%= f.check_box :api_public, class: "checkbox__input"%>
+    <%= f.label :api_public, class: "checkbox__label" do %>
+        Expose in public API?
+        <button class="help-button help-button--small" type="button" data-tippy-content="If checked, all fields in this section may be made visible in API clients.">What does this mean?</button>
+    <% end %>
+</div>
+
 <h2 class="page-subheading">Fields</h2>
 <section class="repeater">
     <ul class="repeater__panels" aria-live="polite">

--- a/app/views/admin/custom_field_sections/index.html.erb
+++ b/app/views/admin/custom_field_sections/index.html.erb
@@ -12,7 +12,8 @@
     <thead>
       <th>Name</th>
       <th>Fields</th>
-      <th>Visibility</th>
+      <th>Visible to community users</th>
+      <th>Exposed in API</th>
       <th>Sort order</th>
     </thead>
     <tbody>
@@ -22,9 +23,16 @@
           <td><%= s.custom_fields.map{ |f| f.key }.join(", ") %></td>
           <td>
             <% if s.public %>
-              <span class="tag">Public</span>
+              <%= image_tag "tick-blue.svg", alt: "Yes" %>
             <% else %>
-              <span class="tag tag--grey">Admin only</span>
+              —
+            <% end %>
+          </td>
+          <td>
+            <% if s.api_public %>
+              <%= image_tag "tick-blue.svg", alt: "Yes" %>
+            <% else %>
+              —
             <% end %>
           </td>
           <td><%= s.sort_order %></td>

--- a/db/migrate/20210111150052_add_api_visibility_to_custom_field.rb
+++ b/db/migrate/20210111150052_add_api_visibility_to_custom_field.rb
@@ -1,0 +1,5 @@
+class AddAPIVisibilityToCustomField < ActiveRecord::Migration[6.0]
+  def change
+    add_column :custom_fields, :api_public, :boolean
+  end
+end

--- a/db/migrate/20210111150054_add_api_visibility_to_custom_field_sections.rb
+++ b/db/migrate/20210111150054_add_api_visibility_to_custom_field_sections.rb
@@ -1,0 +1,6 @@
+class AddAPIVisibilityToCustomFieldSections < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :custom_fields, :api_public
+    add_column :custom_field_sections, :api_public, :boolean
+  end
+end


### PR DESCRIPTION
- add checkbox and model boolean on custom field sections for `api_public`.
- update custom fields sections index view to show that boolean
- modify indexed service serialiser to show meta only if their parent custom field section is public