### PR TITLE
Possible way to filter unwanted fields in comparison

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -293,8 +293,12 @@ class Service < ApplicationRecord
     last_approved_version = last_approved_snapshot
     self.as_json.each do |key, value|
 
+      # Remove nested ignorable fields
+      current_value = remove_ignorable_nested_fields(key, value)
+      last_approved_value = remove_ignorable_nested_fields(key, last_approved_version.object[key])
+
       # eql? lets us do a slightly more intelligent comparison than simple "===" equality
-      unless remove_ignorable_nested_fields(key, value).eql?(remove_ignorable_nested_fields(key, last_approved_version.object[key]))
+      unless current_value.eql?(last_approved_value)
         # we don't care about these fields
         unless ignorable_fields.include?(key)
           changed_fields << key

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -282,7 +282,7 @@ class Service < ApplicationRecord
   def remove_ignorable_nested_fields(key, value)
     case key
     when "taxonomies"
-      value.map{ |nested_item| nested_item.except( *ignorable_nested_taxonomy_fields )}
+      value.map{ |taxonomy| taxonomy.except( *ignorable_nested_taxonomy_fields )}
     else
       value
     end


### PR DESCRIPTION
Doesn't feel great - Like, in a way, all of the taxonomy fields should be ignored. It's actually the service_taxonomies we're interested in, isn't it? Cos that's what will change when a community user updates taxonomies. Think this would fix in short term but, but might need re-thinking.