### PR TITLE
Don't create a version on destroy

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -5,6 +5,7 @@ class Service < ApplicationRecord
   include NormalizeBlankValues
 
   has_paper_trail(
+    on: [:create, :update],
     meta: {
       object: proc { |s| s.as_json },
       object_changes: proc { |s| s.saved_changes.as_json }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -316,4 +316,19 @@ class Service < ApplicationRecord
   def publicly_visible?
     visible && discarded_at.nil?
   end
+
+  def destroy_associated_data
+    versions.destroy_all
+    service_at_locations.destroy_all
+    service_taxonomies.destroy_all
+    contacts.destroy_all
+    local_offer&.destroy
+    regular_schedules.destroy_all
+    cost_options.destroy_all
+    feedbacks.destroy_all
+    notes.destroy_all
+    watches.destroy_all
+    meta.destroy_all
+    links.destroy_all
+  end
 end

--- a/lib/tasks/process_permanent_deletions.rake
+++ b/lib/tasks/process_permanent_deletions.rake
@@ -6,18 +6,7 @@ task :process_permanent_deletions => :environment  do
       service_id = s.id
       next unless s.marked_for_deletion
       next unless s.marked_for_deletion <= DateTime.now.beginning_of_day - 30.days
-      s.versions.destroy_all
-      s.service_at_locations.destroy_all
-      s.service_taxonomies.destroy_all
-      s.contacts.destroy_all
-      s.local_offer&.destroy
-      s.regular_schedules.destroy_all
-      s.cost_options.destroy_all
-      s.feedbacks.destroy_all
-      s.notes.destroy_all
-      s.watches.destroy_all
-      s.meta.destroy_all
-      s.links.destroy_all
+      s.destroy_associated_data
       s.destroy
       puts "Destroyed service #{service_id} and dependents"
       destroyed_services_count += 1


### PR DESCRIPTION
When a service is destroyed, it's version history is destroyed with it. Therefore we don't want to create a version when we destroy it 