### PR TITLE
Add titles to truncated names so the full names appear on hover

### DIFF
--- a/app/views/admin/ofsted/pending.html.erb
+++ b/app/views/admin/ofsted/pending.html.erb
@@ -8,7 +8,7 @@
     <% @requests.each do |s| %>
     <li class="todo-list__item">
         <div>
-            <h2><%= link_to s.display_name.truncate(25), admin_ofsted_path(s) %></h2>
+            <h2><%= link_to s.display_name.truncate(25), admin_ofsted_path(s), title: s.display_name %></h2>
             <p>
                 <%= time_ago_in_words(s.updated_at).humanize %> ago
                 <span class="todo-list__divider">|</span>

--- a/app/views/admin/requests/index.html.erb
+++ b/app/views/admin/requests/index.html.erb
@@ -8,7 +8,7 @@
     <% @requests.each do |s| %>
       <li class="todo-list__item">
         <div>
-          <h2><%= link_to s.display_name.truncate(25), admin_service_path(s) %></h2>
+          <h2><%= link_to s.display_name.truncate(25), admin_service_path(s), title: s.display_name %></h2>
           <p>
             <%= time_ago_in_words(s.updated_at).humanize %> ago
             <% if s.last_version && s.last_version.whodunnit %>

--- a/app/views/shared/poppables/_organisation.html.erb
+++ b/app/views/shared/poppables/_organisation.html.erb
@@ -1,5 +1,5 @@
 <span class="poppable">
-    <%= link_to o.display_name.truncate(25), admin_organisation_url(o), class: "poppable__control" %>
+    <%= link_to o.display_name.truncate(25), admin_organisation_url(o), title: o.display_name, class: "poppable__control" %>
 
     <div class="poppable-card">
         <div class="poppable-card__inner">


### PR DESCRIPTION
As per [user feedback](https://docs.google.com/spreadsheets/d/123YCOIITHivQGTronQYxvPfL4d-3snlo/edit#gid=2032181625&range=C17). There were a couple of other places we were truncating names and not showing a title, so I added titles to those too.