### PR TITLE
Redirect admins to service edit page from the feedback form

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -1,32 +1,35 @@
 class FeedbackController < ApplicationController
-    skip_before_action :authenticate_user!
-    before_action :no_admins
-    before_action :set_service
+  skip_before_action :authenticate_user!
+  before_action :set_service
+  before_action :redirect_if_admin!
 
-    def index
-        @feedback = @service.feedbacks.new
+  def index
+    @feedback = @service.feedbacks.new
+  end
+
+  def create
+    @feedback = @service.feedbacks.build(feedback_params)
+    if @feedback.save
+      render "create"
+    else
+      render "index"
     end
+  end
 
-    def create
-        @feedback = @service.feedbacks.build(feedback_params)
-        if @feedback.save
-            render "create"
-        else
-            render "index"
-        end
-    end
+  private
 
-    private
+  def set_service
+    @service = Service.find(params[:service_id])
+  end
 
-    def set_service
-        @service = Service.find(params[:service_id])
-    end
+  def redirect_if_admin!
+    redirect_to admin_service_path(@service) if current_user&.admin?
+  end
 
-    def feedback_params
-        params.require(:feedback).permit(
-            :body,
-            :topic
-        )
-    end
-
+  def feedback_params
+    params.require(:feedback).permit(
+      :body,
+      :topic
+    )
+  end
 end

--- a/spec/factories/service.rb
+++ b/spec/factories/service.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     after(:create) do |service|
       create_list(:location, 1, services: [service])
     end
+    organisation
   end
 
   factory :service_with_all_associations, class: 'Service' do

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,5 +4,9 @@ FactoryBot.define do
     first_name {Faker::Name.first_name }
     last_name {Faker::Name.last_name }
     password { "password123A" }
+
+    trait :admin do
+      admin { true }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,18 +1,13 @@
-
-
-# This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 
-
-
-
-
 require File.expand_path('../config/environment', __dir__)
+require 'spec_helper'
+require 'rspec/rails'
+require 'devise'
 
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
-require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -66,6 +61,9 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Configure Devise
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/requests/suggesting_feedback_spec.rb
+++ b/spec/requests/suggesting_feedback_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'Suggesting feedback', type: :request do
+  let(:service) { FactoryBot.create :service }
+  let(:admin) { FactoryBot.create :user, :admin }
+
+  context 'logged out' do
+    it 'renders the feedback form' do
+      get "/services/#{service.id}/feedback"
+      expect(response).to_not redirect_to admin_service_path service
+      expect(response.body).to include 'Suggest an edit'
+    end
+  end
+
+  context 'logged in as an admin' do
+    it 'redirects to the service edit page' do
+      sign_in admin
+      get "/services/#{service.id}/feedback"
+      expect(response).to redirect_to admin_service_path service
+    end
+  end
+end


### PR DESCRIPTION
As per [user feedback](https://docs.google.com/spreadsheets/d/123YCOIITHivQGTronQYxvPfL4d-3snlo/edit#gid=2032181625&range=C15), we were redirecting admins who clicked 'Suggest an edit' in Scout (which opens the feedback form in Outpost) to their dashboard, instead of to the edit page of the service they came from. This fixes that.

As part of this I've added Devise helpers to our RSpec config, so that we can write nice RSpec tests involving logged in users 😄 