### PR TITLE
Fix service taxonomy bug

### DIFF
--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -13,7 +13,14 @@ RSpec.describe Service, type: :model do
       root_taxonomy = Taxonomy.create({ name: 'Root' })
       child1_taxonomy = Taxonomy.create({ name: 'Child 1', parent: root_taxonomy })
       @service = Service.create!({ organisation: @organisation, name: 'Test Service', description: "Test service description", taxonomies: [child1_taxonomy] })
-      expect(@service.taxonomies).to match_array([root_taxonomy, child1_taxonomy])
+      expect(@service.reload.taxonomies).to match_array([root_taxonomy, child1_taxonomy])
+    end
+
+    it 'should not remove taxonomy roots if they were passed as params' do
+      root_taxonomy = Taxonomy.create({ name: 'Root' })
+      child1_taxonomy = Taxonomy.create({ name: 'Child 1', parent: root_taxonomy })
+      @service = Service.create!({ organisation: @organisation, name: 'Test Service', description: "Test service description", taxonomies: [root_taxonomy, child1_taxonomy] })
+      expect(@service.reload.taxonomies).to match_array([root_taxonomy, child1_taxonomy])
     end
   end
 


### PR DESCRIPTION
We had a bug where if a user added a nested taxonomy and its parent to a new service they were creating, the `ServiceTaxonomy` for the child taxonomy was created correctly, but the one for the parent would be created without being associated to the service.

This PR fixes that - thanks @dtt101 for the solution! 🎉 

Side note - once this is merged & deployed, there's a manual cleanup task to go and delete all the `ServiceTaxonomies` that were created without a `service_id`.