### PR TITLE
Upgrade puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '~> 2.6.0'
 
 gem 'rails', '~> 6.0.3', '>= 6.0.3.6'
 gem 'pg', '>= 0.18', '< 2.0'
-gem 'puma', '~> 4.3'
+gem 'puma', '~> 5.3'
 gem 'sass-rails', '>= 6'
 gem 'webpacker', '~> 4.0'
 gem 'turbolinks', '~> 5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -236,7 +236,7 @@ GEM
       activerecord (>= 5.2)
       activesupport (>= 5.2)
     public_suffix (4.0.3)
-    puma (4.3.5)
+    puma (5.3.1)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -430,7 +430,7 @@ DEPENDENCIES
   paper_trail
   pg (>= 0.18, < 2.0)
   pg_search
-  puma (~> 4.3)
+  puma (~> 5.3)
   rack-cors
   rack-mini-profiler
   rails (~> 6.0.3, >= 6.0.3.6)


### PR DESCRIPTION
Running Mac OSX I encountered an error which goes away when I update to latest puma as per https://github.com/puma/puma/issues/2342

For reviewers: I don't currently have access to a staging or CI environment to test this cc @em-cd @userman123 

```
Fetching puma 4.3.5
Installing puma 4.3.5 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
An error occurred while installing puma (4.3.5), and Bundler cannot
continue.
Make sure that `gem install puma -v '4.3.5' --source 'https://rubygems.org/'`
succeeds before bundling.
```