### PR TITLE
Bug fix: warn users on unsaved changes

### DIFF
--- a/app/javascript/packs/warn-unsaved-changes.js
+++ b/app/javascript/packs/warn-unsaved-changes.js
@@ -3,7 +3,7 @@ const form = document.querySelector("[data-warn-unsaved-changes]")
 if(form){
     let unsavedChanges = false
 
-    form.querySelectorAll("input, textarea").forEach(input => {
+    form.querySelectorAll("input, textarea, select").forEach(input => {
         input.addEventListener("keyup", () => unsavedChanges = true)
         input.addEventListener("change", () => unsavedChanges = true)
     })
@@ -17,7 +17,12 @@ if(form){
     form.addEventListener("submit", e => unsavedChanges = false)
 
     window.addEventListener("beforeunload", e => {
-        if(unsavedChanges && !confirm(message)) e.preventDefault()
+        if(unsavedChanges) {
+            e.preventDefault()
+            // Chrome requires returnValue to be set, otherwise it won't show a
+            // confirm dialog.
+            e.returnValue = message
+        }
     })
 
     window.addEventListener("turbolinks:before-visit", e => {


### PR DESCRIPTION
Fixes two bugs:
* Warn users about unsaved changes to select dropdowns
* Bug with Chrome ignoring the confirm dialog because of a missing `returnValue` (more info in [the `onbeforeunload` docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload))

I tried to test this behaviour with Cucumber and found that it's really hard to do! Browsers seem to handle `beforeunload` in different ways depending on whether they think the user has interacted with the page. So while this works for me in Firefox (and Chrome now too, with this fix), the same actions carried out using Capybara in a feature test in Firefox does not trigger the alert to pop up, even though the event fires.

We could unit test the JS, but I'm not sure that's really a valid approach since the tests could pass but the user might still not see the dialog.

I think ideally we need to move away from using `beforeunload` as it's too unpredictable (it seems to have other issues with mobile also). We could submit notes via Ajax but as there are other places we use this code too, this might be too big a task for just now - what do you think @jhackett1?