### PR TITLE
Fix taxonomy counter issue

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -240,7 +240,9 @@ class Service < ApplicationRecord
 
   def add_parent_taxonomies
     self.taxonomies.each do |t|
-      self.taxonomies << t.ancestors
+      t.ancestors.each do |a|
+        self.taxonomies << a unless self.taxonomies.exists?(a.id)
+      end
     end
   end
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -63,7 +63,7 @@ class Service < ApplicationRecord
 
   # callbacks
   after_save :notify_watchers
-  before_save :add_parent_taxonomies
+  after_save :add_parent_taxonomies
   before_save :skip_nested_indexes
 
   filterrific(

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -4,7 +4,7 @@ class Taxonomy < ApplicationRecord
         dependent: :destroy, 
         numeric_order: true
 
-    has_many :service_taxonomies
+    has_many :service_taxonomies, dependent: :destroy
     has_many :services, -> { distinct }, through: :service_taxonomies
 
     attr_accessor :skip_mongo_callbacks

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -5,7 +5,7 @@ class Taxonomy < ApplicationRecord
         numeric_order: true
 
     has_many :service_taxonomies
-    has_many :services, through: :service_taxonomies
+    has_many :services, -> { distinct }, through: :service_taxonomies
 
     attr_accessor :skip_mongo_callbacks
     after_commit :update_index, if: -> { skip_mongo_callbacks == !true }

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -22,6 +22,15 @@ RSpec.describe Service, type: :model do
       @service = Service.create!({ organisation: @organisation, name: 'Test Service', description: "Test service description", taxonomies: [root_taxonomy, child1_taxonomy] })
       expect(@service.reload.taxonomies).to match_array([root_taxonomy, child1_taxonomy])
     end
+
+    it 'should not create additional root service taxonomy relations on subsequent saves' do
+      root_taxonomy = Taxonomy.create({ name: 'Root' })
+      child1_taxonomy = Taxonomy.create({ name: 'Child 1', parent: root_taxonomy })
+      @service = Service.create!({ organisation: @organisation, name: 'Test Service', description: "Test service description", taxonomies: [root_taxonomy, child1_taxonomy] })
+      expect(ServiceTaxonomy.where(service_id: @service.id).count).to eq(2)
+      @service.save
+      expect(ServiceTaxonomy.where(service_id: @service.id).count).to eq(2)
+    end
   end
 
   describe '#destroy' do


### PR DESCRIPTION
Taxonomy counts way to high for top level taxonomies:
![Screenshot 2021-08-11 at 13 26 33](https://user-images.githubusercontent.com/5345477/129028296-c70f5254-a8ba-4c2e-9a34-bd2c2adac97c.png)
After a bit of debugging, it seems that every time a service was being saved, it was adding an extra top level service_taxonomy record for each second level taxonomy.

So for example, a service with "Clubs and groups", "Places to go" and "Activities for babies and toddlers" would get 3 new "Things to do" taxonomies every time it was saved. I would have thought that [this](https://github.com/wearefuturegov/outpost/blob/2757f237259da689f22ec447f9450d6f32eb0f57/app/models/service.rb#L47) would have solved, but apparently not. 

Changes committed here seem to resolve the issue, from some manual testing. Might need a rake task to clean up prod db too. 