### PR TITLE
Include specific labels in the mongodb

### DIFF
--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -1,5 +1,10 @@
 class IndexedServicesSerializer < ActiveModel::Serializer
   
+  TARGET_DIRECTORY_MAP = {
+      'bod': 'Buckinghamshire Online Directory',
+      'bfis': 'Family Information Service',
+  }
+
   attributes :id, 
     :updated_at, 
     :name, 
@@ -21,7 +26,9 @@ class IndexedServicesSerializer < ActiveModel::Serializer
     :status
 
   has_many :target_directories do 
-    object.labels.where(["name = ? or name = ?", "Family Information Service", "Buckinghamshire Online Directory"])
+    object.labels.where(["name = ? or name = ?", *TARGET_DIRECTORY_MAP.values]).map do |directory| 
+      { id: directory.id, name: directory.name, label: TARGET_DIRECTORY_MAP.key(directory.name) }
+    end
   end
   
   has_many :locations do

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -20,6 +20,10 @@ class IndexedServicesSerializer < ActiveModel::Serializer
     :created_at,
     :status
 
+  has_many :target_directories do 
+    object.labels.where(["name = ? or name = ?", "Family Information Service", "Buckinghamshire Online Directory"])
+  end
+  
   has_many :locations do
     object.locations.where(visible: true)
   end


### PR DESCRIPTION
@userman123 I couldn't get the scope tagged with approach to work here so instead I'm just adding labels (only "Family Information Service", "Buckinghamshire Online Directory") 

but I can't work out how to rename these to bfis and bod when it goes into mongo.

[This was the closest solution I could find but it was erroring:](https://stackoverflow.com/questions/4137824/how-to-elegantly-rename-all-keys-in-a-hash-in-ruby)

```ages = { 'Bruce' => 32, 'Clark' => 28 }
mappings = { 'Bruce' => 'Bruce Wayne', 'Clark' => 'Clark Kent' }

ages.transform_keys(&mappings.method(:[]))
#=> { 'Bruce Wayne' => 32, 'Clark Kent' => 28 }```


I might have to come back to this section 