### PR TITLE
Add new filtered pages for users

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,106 +1,125 @@
 class Admin::UsersController < Admin::BaseController
-    before_action :user_admins_only, only: [:new, :create, :update, :destroy, :reactivate]
-    before_action :set_user, only: [:show, :update, :destroy]
-    
-    def index
-      @filterrific = initialize_filterrific(
-        User,
-        params[:filterrific],
-        select_options: {
-          sorted_by: User.options_for_sorted_by,
-          roles: User.options_for_roles,
-          tagged_with: Service.options_for_labels
-        },
-        persistence_id: false,
-        default_filter_params: {},
-        available_filters: [
-          :sorted_by, 
-          :search,
-          :roles,
-          :tagged_with
-        ],
-        sanitize_params: true,
-      ) || return
+  before_action :user_admins_only, only: [:new, :create, :update, :destroy, :reactivate]
+  before_action :set_user, only: [:show, :update, :destroy]
   
-      @users = @filterrific.find.page(params[:page])
+  def index
+    @filterrific = initialize_filterrific(
+      User,
+      params[:filterrific],
+      select_options: {
+        sorted_by: User.options_for_sorted_by,
+        roles: User.options_for_roles,
+        tagged_with: Service.options_for_labels
+      },
+      persistence_id: false,
+      default_filter_params: {},
+      available_filters: [
+        :sorted_by, 
+        :search,
+        :roles,
+        :tagged_with
+      ],
+      sanitize_params: true,
+    ) || return
 
-      @active_count = User.kept.count
-      @deactivated_count = User.discarded.count
+    @users = @filterrific.find.page(params[:page])
 
-      # shortcut nav
-      if params[:deactivated] === "true"
-        @users = @users.discarded.includes(:organisation)
-      else
-        @users = @users.kept.includes(:organisation)
+    @all_count = User.all.count
+    @active_count = User.kept.count
+    @deactivated_count = User.discarded.count
+
+    if APP_CONFIG["label_quick_links"].present?
+      @directory_user_counts = {}
+      @active_directory_user_counts = {}
+      @deactivated_directory_user_counts = {}
+      APP_CONFIG["label_quick_links"].each do |label_quick_link|
+        users = User.joins(organisation: :services).merge(Service.tagged_with(label_quick_link["value"]))
+        @directory_user_counts[label_quick_link["name"]] = users.count
+        @active_directory_user_counts[label_quick_link["name"]] = users.kept.count
+        @deactivated_directory_user_counts[label_quick_link["name"]] = users.discarded.count
       end
     end
 
-    def new
-      @user = User.new
+    if params[:label].present?
+      @users = @users.joins(organisation: :services).merge(Service.tagged_with(params[:label]))
     end
 
-    def create
-      @user = User.create(user_params)
-      @user.password = SecureRandom.urlsafe_base64
-      if @user.save
-        UserMailer.with(user: @user).invite_from_admin_email.deliver_later
-        redirect_to admin_users_path, notice: "User has been invited."
-      else
-        render "new"
-      end
+    # shortcut nav
+    if params[:deactivated] === "true"
+      @users = @users.discarded.includes(:organisation)
+    elsif params[:deactivated] === "false"
+      @users = @users.kept.includes(:organisation)
+    else
+      @users = @users.includes(:organisation)
     end
+  end
 
-    def update
-      if @user.update(user_params)
-        redirect_to admin_user_path(@user), notice: "User has been updated."
-      else
-        render "show"
-      end
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.create(user_params)
+    @user.password = SecureRandom.urlsafe_base64
+    if @user.save
+      UserMailer.with(user: @user).invite_from_admin_email.deliver_later
+      redirect_to admin_users_path, notice: "User has been invited."
+    else
+      render "new"
     end
+  end
 
-    def show
-      @activities = PaperTrail::Version.order("created_at DESC").where(whodunnit: params[:id]).limit(5)
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_path(@user), notice: "User has been updated."
+    else
+      render "show"
     end
+  end
 
-    def destroy
-      unless @user === current_user
-        @user.discard
-        redirect_to admin_users_path, notice: "That user has been deactivated."
-      else
-        redirect_to admin_user_path(@user), notice: "You can't deactivate yourself."
-      end
+  def show
+    @activities = PaperTrail::Version.order("created_at DESC").where(whodunnit: params[:id]).limit(5)
+  end
+
+  def destroy
+    unless @user === current_user
+      @user.discard
+      redirect_to admin_users_path, notice: "That user has been deactivated."
+    else
+      redirect_to admin_user_path(@user), notice: "You can't deactivate yourself."
     end
+  end
 
-    def reactivate
-      User.find(params[:user_id]).undiscard
-      redirect_to request.referer, notice: "That user has been reactivated."
-    end
+  def reactivate
+    User.find(params[:user_id]).undiscard
+    redirect_to request.referer, notice: "That user has been reactivated."
+  end
 
-    def reset
-      @user = User.find(params[:user_id])
-      token = @user.send(:set_reset_password_token)
-      UserMailer.with(token: token, user: @user).reset_instructions_email.deliver_later
-      redirect_to admin_user_path(@user), notice: "Password reset instructions have been sent by email."
-    end
+  def reset
+    @user = User.find(params[:user_id])
+    token = @user.send(:set_reset_password_token)
+    UserMailer.with(token: token, user: @user).reset_instructions_email.deliver_later
+    redirect_to admin_user_path(@user), notice: "Password reset instructions have been sent by email."
+  end
 
-    private
+  private
 
-    def set_user
-      @user = User.find(params[:id])
-    end
+  def set_user
+    @user = User.find(params[:id])
+  end
 
-    def user_params
-      params.require(:user).permit(
-        :email,
-        :first_name,
-        :last_name,
-        :phone,
-        :admin,
-        :admin_ofsted,
-        :admin_users,
-        :organisation_id,
-        :label_list,
-        :marked_for_deletion
-      )
-    end
+  def user_params
+    params.require(:user).permit(
+      :email,
+      :first_name,
+      :last_name,
+      :phone,
+      :admin,
+      :admin_ofsted,
+      :admin_users,
+      :organisation_id,
+      :label_list,
+      :marked_for_deletion
+    )
+  end
 end

--- a/app/views/admin/users/_filters.html.erb
+++ b/app/views/admin/users/_filters.html.erb
@@ -1,46 +1,46 @@
 <%= form_for_filterrific @filterrific do |f| %>
 
-<%= hidden_field_tag :deactivated, params[:deactivated] %>
+    <%= hidden_field_tag :deactivated, params[:deactivated] %>
 
-<details class="filters" <%= "open" if params[:filterrific] %>>
-    <summary class="filters__control" aria-expanded="false">Filters</summary>
-    <div class="filters__body">
+    <details class="filters" <%= "open" if params[:filterrific] %>>
+        <summary class="filters__control" aria-expanded="false">Filters</summary>
+        <div class="filters__body">
 
-        <%= f.label :sorted_by, "Sort", class: "visually-hidden" %>
-        <%= f.select :sorted_by, @filterrific.select_options[:sorted_by], {}, { class: "filters__select", data: { autosubmit: true }, disabled: params.dig(:filterrific, :search).present? } %>
+            <%= f.label :sorted_by, "Sort", class: "visually-hidden" %>
+            <%= f.select :sorted_by, @filterrific.select_options[:sorted_by], {}, { class: "filters__select", data: { autosubmit: true }, disabled: params.dig(:filterrific, :search).present? } %>
 
-        <%= f.label :roles, "Filter roles", class: "visually-hidden" %>
-        <%= f.select :roles, @filterrific.select_options[:roles], {}, { class: "filters__select", data: { autosubmit: true } }  %>
+            <%= f.label :roles, "Filter roles", class: "visually-hidden" %>
+            <%= f.select :roles, @filterrific.select_options[:roles], {}, { class: "filters__select", data: { autosubmit: true } }  %>
 
-        <%= f.label :in_taxonomy, "Labels", class: "visually-hidden" %>
-        <%= f.select :tagged_with, @filterrific.select_options[:tagged_with], {}, { class: "filters__select", data: { autosubmit: true } }  %>
+            <%= f.label :in_taxonomy, "Labels", class: "visually-hidden" %>
+            <%= f.select :tagged_with, @filterrific.select_options[:tagged_with], {}, { class: "filters__select", data: { autosubmit: true } }  %>
 
-    </div>
-</details>
+        </div>
+    </details>
 
-<header class="actions">
+    <header class="actions">
 
-    <div class="mini-search">
-        <div class="mini-search__form">
-            <%= f.label :search, "Search query", class: "visually-hidden" %>
-            <%= f.text_field :search, class: "mini-search__input" %>
+        <div class="mini-search">
+            <div class="mini-search__form">
+                <%= f.label :search, "Search query", class: "visually-hidden" %>
+                <%= f.text_field :search, class: "mini-search__input" %>
+                <% if params[:filterrific].present? %>
+                <%= link_to image_tag("clear.svg", alt: "Clear search"), reset_filterrific_url, class: "mini-search__submit" %>
+                <% else %>
+                <button class="mini-search__submit">
+                    <%= image_tag "search.svg", alt: "Submit search" %>
+                </button>
+                <% end %>
+            </div>
+
             <% if params[:filterrific].present? %>
-            <%= link_to image_tag("clear.svg", alt: "Clear search"), reset_filterrific_url, class: "mini-search__submit" %>
-            <% else %>
-            <button class="mini-search__submit">
-                <%= image_tag "search.svg", alt: "Submit search" %>
-            </button>
+            <p class="mini-search__count"><%= @users.total_count %> matches</p>
             <% end %>
         </div>
 
-        <% if params[:filterrific].present? %>
-        <p class="mini-search__count"><%= @users.total_count %> matches</p>
+        <% if current_user.admin_users? %>
+        <%= link_to "Invite user", new_admin_user_path, class: "button button--small button--add actions__pull-right" %>
         <% end %>
-    </div>
-
-    <% if current_user.admin_users? %>
-    <%= link_to "Invite user", new_admin_user_path, class: "button button--small button--add actions__pull-right" %>
-    <% end %>
-</header>
+    </header>
 
 <% end %>

--- a/app/views/shared/_services-nav.html.erb
+++ b/app/views/shared/_services-nav.html.erb
@@ -13,9 +13,9 @@
     <% if APP_CONFIG["label_quick_links"].present? %>
         <% APP_CONFIG["label_quick_links"].each do |label_quick_link| %>
             <% if (params[:label] === label_quick_link["value"]) %>
-                <span class="shortcuts__current"><%= label_quick_link["name"] %></span>
+                <span class="shortcuts__current"><%= label_quick_link["value"] %></span>
             <% else %>
-                <span class="shortcuts__link"><%= link_to label_quick_link["name"], admin_services_path(label: label_quick_link["value"])%></span>
+                <span class="shortcuts__link"><%= link_to label_quick_link["value"], admin_services_path(label: label_quick_link["value"])%></span>
             <% end %>
             <span class="shortcuts__count">(<%= @label_quick_link_counts[label_quick_link["name"]] %>)</span>
             <span class="shortcuts__divider">|</span>

--- a/app/views/shared/_users-nav.html.erb
+++ b/app/views/shared/_users-nav.html.erb
@@ -1,20 +1,67 @@
 <nav class="shortcuts">
 
-    <% if params[:deactivated] === "true" %>
-        <%= link_to "Active", admin_users_path, class: "shortcuts__link" %>
+    <% if params[:deactivated].present? || params[:label].present? %>
+        <%= link_to "All", admin_users_path, class: "shortcuts__link" %>
     <% else %>
+        <span class="shortcuts__current">All</span>
+    <% end %>
+
+    <span class="shortcuts__count">(<%= @all_count %>)</span>
+
+    <span class="shortcuts__divider">|</span>
+
+    <% if params[:deactivated] === "false" && !params[:label].present? %>
         <span class="shortcuts__current">Active</span>
+    <% else %>
+        <%= link_to "Active", admin_users_path(deactivated: false), class: "shortcuts__link" %>
     <% end %>
 
     <span class="shortcuts__count">(<%= @active_count %>)</span>
 
     <span class="shortcuts__divider">|</span>
+
     
-    <% if params[:deactivated] === "true" %>
+    <% if params[:deactivated] === "true" && !params[:label].present? %>
         <span class="shortcuts__current">Deactivated</span>
     <% else %>
         <%= link_to_unless_current "Deactivated", admin_users_path(deactivated: true), class: "shortcuts__link" %>
     <% end %>
     
     <span class="shortcuts__count">(<%= @deactivated_count %>)</span>
+
+    <% if APP_CONFIG["label_quick_links"].present? %>
+        <% APP_CONFIG["label_quick_links"].each do |label_quick_link| %>
+            <br>
+
+            <% if (params[:label] === label_quick_link["value"] && !params[:deactivated].present?) %>
+                <span class="shortcuts__current"><%= label_quick_link["value"] %></span>
+            <% else %>
+                <span class="shortcuts__link"><%= link_to label_quick_link["value"], admin_users_path(label: label_quick_link["value"])%></span>
+            <% end %>
+            <span class="shortcuts__count">(<%= @directory_user_counts[label_quick_link["name"]] %>)</span>
+            <span class="shortcuts__divider">|</span>
+
+            <% if params[:deactivated] === "false" && params[:label] === label_quick_link['value'] %>
+                <span class="shortcuts__current">Active</span>
+            <% else %>
+                <%= link_to "Active", admin_users_path(label: label_quick_link['value'], deactivated: false), class: "shortcuts__link" %>
+            <% end %>
+
+            <span class="shortcuts__count">(<%= @active_directory_user_counts[label_quick_link['name']] %>)</span>
+
+            <span class="shortcuts__divider">|</span>
+
+            <% if params[:deactivated] === "true" && params[:label] === label_quick_link['value'] %>
+                <span class="shortcuts__current">Deactivated</span>
+            <% else %>
+                <%= link_to_unless_current "Deactivated", admin_users_path(deactivated: true, label: label_quick_link['value']), class: "shortcuts__link" %>
+            <% end %>
+
+            <span class="shortcuts__count">(<%= @deactivated_directory_user_counts[label_quick_link['name']] %>)</span>
+
+
+        <% end %>
+    <% end %>
+
+
 </nav>


### PR DESCRIPTION
WIP!

Adds some new filtered user pages for admins:
* All - returns all users, active or deactivated
* For each directory, all the users belonging to an organisation that has services in that directory
* For each directory, the active and deactivated users that belong to an organisation with services in that directory

![Screenshot 2021-08-25 at 12 26 18](https://user-images.githubusercontent.com/11888656/130782578-905956ea-f1ad-43b6-a6a0-a857c353a01a.png)
