### PR TITLE
better error checking for taxonomy filtering

### DIFF
--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -2,16 +2,23 @@ class API::V1::TaxonomiesController < ApplicationController
     skip_before_action :authenticate_user!
   
     def index
-        # scout sends through lowercase label 'bfis', 'bod' etc - look up the name in app config to send to the application
-        @get_value_from_label = APP_CONFIG['directories'].find{|directory| directory["label"] === params[:directory]}["value"];
-        
-        if params[:directory].present? && APP_CONFIG['directories'].map{|d| d['label']}.include?(params[:directory])
-            render json: json_tree(Taxonomy.filter_by_directory(@get_value_from_label).hash_tree)
-        elsif params[:directory].present? 
-            render json: {'yo': 'ho'}
-        else
+
+        if params[:directory].present?
+
+            # scout sends through lowercase label 'bfis', 'bod' etc - look up the name in app config to send to the application
+            @get_value_from_label = APP_CONFIG['directories'].find{|directory| directory["label"] === params[:directory]};
+
+            if !@get_value_from_label.nil?
+                render json: json_tree(Taxonomy.filter_by_directory(@get_value_from_label["value"]).hash_tree)
+            else 
+                render json: {}
+            end
+
+        else 
             render json: json_tree(Taxonomy.hash_tree)
         end
+        
+       
     end
 
     private


### PR DESCRIPTION
Small fix since I realised there was some dummy code in there still. Improved the error checking a bit too.

if `directory===valid label` it shows the taxonomies linked to it
if `directory!=valid label` it shows `{}`
if `no directory` it shows all taxonomies

however this functionality is probably a bit redundant for this install since when scout is deployed it builds a list of taxonomies from `/api/v1/taxonomy?dir=bod` but that list is only populated with ones that have a bod directory on them. If they add a new service that taxonomy wont appear on scout because its cached - or do we trigger a rebuild of scout (which I don't think we do)