### PR TITLE
if there are no db entries don't error

### DIFF
--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -3,13 +3,14 @@ class API::V1::TaxonomiesController < ApplicationController
   
     def index
 
-        if params[:directory].present?
+        if params[:directory].present? && APP_CONFIG['directories'].present?
 
             # scout sends through lowercase label 'bfis', 'bod' etc - look up the name in app config to send to the application
             @get_value_from_label = APP_CONFIG['directories'].find{|directory| directory["label"] === params[:directory]};
+            @results = (!@get_value_from_label.nil?) ? Taxonomy.filter_by_directory(@get_value_from_label["value"]) : {};
 
-            if !@get_value_from_label.nil?
-                render json: json_tree(Taxonomy.filter_by_directory(@get_value_from_label["value"]).hash_tree)
+            if !@get_value_from_label.nil? && @results.count > 0
+                render json: json_tree(@results.hash_tree)
             else 
                 render json: {}
             end

--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -6,11 +6,12 @@ class API::V1::TaxonomiesController < ApplicationController
         if params[:directory].present? && APP_CONFIG['directories'].present?
 
             # scout sends through lowercase label 'bfis', 'bod' etc - look up the name in app config to send to the application
-            @get_value_from_label = APP_CONFIG['directories'].find{|directory| directory["label"] === params[:directory]};
-            @results = (!@get_value_from_label.nil?) ? Taxonomy.filter_by_directory(@get_value_from_label["value"]) : {};
+            get_value_from_label = APP_CONFIG['directories'].find{|directory| directory["label"] === params[:directory]};
+            value = get_value_from_label.nil? ? nil : get_value_from_label["value"]
+            results = Taxonomy.filter_by_directory(value);
 
-            if !@get_value_from_label.nil? && @results.count > 0
-                render json: json_tree(@results.hash_tree)
+            if results.count > 0
+                render json: json_tree(results.hash_tree)
             else 
                 render json: {}
             end

--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -7,7 +7,7 @@ class API::V1::TaxonomiesController < ApplicationController
 
             # scout sends through lowercase label 'bfis', 'bod' etc - look up the name in app config to send to the application
             get_value_from_label = APP_CONFIG['directories'].find{|directory| directory["label"] === params[:directory]};
-            value = get_value_from_label.nil? ? nil : get_value_from_label["value"]
+            value = APP_CONFIG['directories'].find{|directory| directory["label"] === params[:directory]}&.fetch('value');
             results = Taxonomy.filter_by_directory(value);
 
             if results.count > 0


### PR DESCRIPTION
One more little fix - if theres no directories in the tags db then the taxonomies call errors - this will just set it to return {} if theres nothing in the tags column