### PR TITLE
Feature/directory taxonomies

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -30,17 +30,15 @@ class Admin::BaseController < ApplicationController
             }
           }
       
-          if Directory.all.any?
-            Directory.all.each do |directory|
-              service = directory.services
-              @service_dir_counts = {
-                all: service.kept.count,
-                ofsted: service.kept.ofsted_registered.count,
-                pending: service.kept.where(approved: nil).count,
-                archived: service.discarded.count
-              }
-              @service_counts[directory.name] = @service_dir_counts
-            end
+          Directory.all.each do |directory|
+            service = directory.services
+            @service_dir_counts = {
+              all: service.kept.count,
+              ofsted: service.kept.ofsted_registered.count,
+              pending: service.kept.where(approved: nil).count,
+              archived: service.discarded.count
+            }
+            @service_counts[directory.name] = @service_dir_counts
           end
 
     end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -30,9 +30,9 @@ class Admin::BaseController < ApplicationController
             }
           }
       
-          if APP_CONFIG["directories"].present?
-            APP_CONFIG["directories"].each do |directory|
-              service = Service.in_directory(directory["value"])
+          if Directory.all.any?
+            Directory.all.each do |directory|
+              service = directory.services
               @service_dir_counts = {
                 all: service.kept.count,
                 ofsted: service.kept.ofsted_registered.count,

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -39,7 +39,7 @@ class Admin::BaseController < ApplicationController
                 pending: service.kept.where(approved: nil).count,
                 archived: service.discarded.count
               }
-              @service_counts[directory["value"]] = @service_dir_counts
+              @service_counts[directory.name] = @service_dir_counts
             end
           end
 

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -49,7 +49,6 @@ class Admin::ServicesController < Admin::BaseController
   end
 
   def update
-    
     # validation
     #directory_list_valid = params[:service][:directory_list].any? { |s| APP_CONFIG['directories'].any? { |d| d["value"] === s} }
     #directory_list_valid = !(params[:service][:directory_list] & APP_CONFIG['directories'].map{|d| d['value']}).empty?
@@ -123,7 +122,7 @@ class Admin::ServicesController < Admin::BaseController
       :marked_for_deletion,
       :free,
       :ofsted_item_id,
-      directories: [],
+      directory_ids: [],
       taxonomy_ids: [],
       send_need_ids: [],
       suitability_ids: [],

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -49,10 +49,6 @@ class Admin::ServicesController < Admin::BaseController
   end
 
   def update
-    # validation
-    #directory_list_valid = params[:service][:directory_list].any? { |s| APP_CONFIG['directories'].any? { |d| d["value"] === s} }
-    #directory_list_valid = !(params[:service][:directory_list] & APP_CONFIG['directories'].map{|d| d['value']}).empty?
-
     # force paper trail version to be saved
     @service.updated_at = Time.now
     if @service.update(service_params)

--- a/app/controllers/admin/taxonomies_controller.rb
+++ b/app/controllers/admin/taxonomies_controller.rb
@@ -59,7 +59,8 @@ class Admin::TaxonomiesController < Admin::BaseController
     params.require(:taxonomy).permit(
       :name,
       :parent_id,
-      :sort_order
+      :sort_order,
+      directory_ids: []
     )
   end
 

--- a/app/controllers/admin/taxonomies_controller.rb
+++ b/app/controllers/admin/taxonomies_controller.rb
@@ -71,14 +71,12 @@ class Admin::TaxonomiesController < Admin::BaseController
     @taxonomy_counts = {}
     @taxonomy_counts[:all] = @taxonomy_counts_all
 
-    if Directory.any?
-      Directory.all.each do |directory|
-        tax = Taxonomy.filter_by_directory(directory.name)
-        @taxonomy_dir_counts = {
-          all: tax.count
-        }
-        @taxonomy_counts[directory.name] = @taxonomy_dir_counts
-      end
+    Directory.all.each do |directory|
+      tax = Taxonomy.filter_by_directory(directory.name)
+      @taxonomy_dir_counts = {
+        all: tax.count
+      }
+      @taxonomy_counts[directory.name] = @taxonomy_dir_counts
     end
   end
 

--- a/app/controllers/admin/taxonomies_controller.rb
+++ b/app/controllers/admin/taxonomies_controller.rb
@@ -37,7 +37,7 @@ class Admin::TaxonomiesController < Admin::BaseController
   private
 
   def set_taxonomies
-    if params[:directory].present?  && APP_CONFIG['directories'].map{|d| d['value']}.include?(params[:directory])
+    if params[:directory].present? && Directory.where(name: params[:directory]).any?
       @taxonomies = Taxonomy.filter_by_directory(params[:directory]).hash_tree
     elsif params[:directory].present? 
       redirect_to admin_taxonomies_path, notice: "Directory doesn't exist."
@@ -70,13 +70,13 @@ class Admin::TaxonomiesController < Admin::BaseController
     @taxonomy_counts = {}
     @taxonomy_counts[:all] = @taxonomy_counts_all
 
-    if APP_CONFIG["directories"].present?
-      APP_CONFIG["directories"].each do |directory|
-        tax = Taxonomy.filter_by_directory(directory["value"])
+    if Directory.any?
+      Directory.all.each do |directory|
+        tax = Taxonomy.filter_by_directory(directory.name)
         @taxonomy_dir_counts = {
           all: tax.count
         }
-        @taxonomy_counts[directory["value"]] = @taxonomy_dir_counts
+        @taxonomy_counts[directory.name] = @taxonomy_dir_counts
       end
     end
   end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -117,16 +117,14 @@ class Admin::UsersController < Admin::BaseController
     @user_counts = {}
     @user_counts[:all] = @user_counts_all
 
-    if Directory.any?
-      Directory.all.each do |directory|
-        users = User.in_directory(directory.name);
-        @user_dir_counts = {
-          all: users.count,
-          active: users.kept.count,
-          deactivated: users.discarded.count
-        }
-        @user_counts[directory.name] = @user_dir_counts
-      end
+    Directory.all.each do |directory|
+      users = User.in_directory(directory.name);
+      @user_dir_counts = {
+        all: users.count,
+        active: users.kept.count,
+        deactivated: users.discarded.count
+      }
+      @user_counts[directory.name] = @user_dir_counts
     end
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -117,15 +117,15 @@ class Admin::UsersController < Admin::BaseController
     @user_counts = {}
     @user_counts[:all] = @user_counts_all
 
-    if APP_CONFIG["directories"].present?
-      APP_CONFIG["directories"].each do |directory|
-        users = User.in_directory(directory["value"]);
+    if Directory.any?
+      Directory.all.each do |directory|
+        users = User.in_directory(directory.name);
         @user_dir_counts = {
           all: users.count,
           active: users.kept.count,
           deactivated: users.discarded.count
         }
-        @user_counts[directory["value"]] = @user_dir_counts
+        @user_counts[directory.name] = @user_dir_counts
       end
     end
   end

--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -3,7 +3,7 @@ class API::V1::TaxonomiesController < ApplicationController
   
     def index
 
-        if params[:directory].present? && Directory.any?
+        if params[:directory].present? && Directory.where(label: params[:directory]).any?
 
             # scout sends through lowercase label 'bfis', 'bod' etc - look up the name in app config to send to the application
             value = Directory.where(label: params[:directory]).first.name

--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -3,10 +3,10 @@ class API::V1::TaxonomiesController < ApplicationController
   
     def index
 
-        if params[:directory].present? && APP_CONFIG['directories'].present?
+        if params[:directory].present? && Directory.any?
 
             # scout sends through lowercase label 'bfis', 'bod' etc - look up the name in app config to send to the application
-            value = APP_CONFIG['directories'].find{|directory| directory["label"] === params[:directory]}&.fetch('value')
+            value = Directory.where(label: params[:directory]).first.name
             results = Taxonomy.filter_by_directory(value)
 
             if results.count > 0

--- a/app/helpers/services_helper.rb
+++ b/app/helpers/services_helper.rb
@@ -31,10 +31,11 @@ module ServicesHelper
   end
 
   def valid_directory_list
-    if APP_CONFIG['directories'].present?
-      APP_CONFIG['directories'].map{ |m| [ m["value"] ] } 
-    else 
-      []
-    end
+    Directory.all.map{|dir| [dir.name, dir.id]}
+    # if APP_CONFIG['directories'].present?
+    #   APP_CONFIG['directories'].map{ |m| [ m["value"] ] } 
+    # else 
+    #   []
+    # end
   end
 end

--- a/app/helpers/services_helper.rb
+++ b/app/helpers/services_helper.rb
@@ -32,10 +32,5 @@ module ServicesHelper
 
   def valid_directory_list
     Directory.all.map{|dir| [dir.name, dir.id]}
-    # if APP_CONFIG['directories'].present?
-    #   APP_CONFIG['directories'].map{ |m| [ m["value"] ] } 
-    # else 
-    #   []
-    # end
   end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,6 +6,7 @@ class ApplicationRecord < ActiveRecord::Base
     h.each do |key, value|
       case value.class.to_s
       when 'Array'
+        next if key == "directories" # Ignore old array column 'directories' as not using this anymore and may cause errors
         next unless Object.const_defined?(key.camelize.singularize)
         h[key].map! { |e|
           Object.const_get(key.camelize.singularize).from_hash e }

--- a/app/models/directory.rb
+++ b/app/models/directory.rb
@@ -1,6 +1,7 @@
 class Directory < ApplicationRecord
   has_and_belongs_to_many :services
-
+  validates_presence_of :name, :label
+  validates_uniqueness_of :name, :label
   # def display_name
   #   name.humanize
   # end

--- a/app/models/directory.rb
+++ b/app/models/directory.rb
@@ -1,0 +1,11 @@
+class Directory < ApplicationRecord
+  has_and_belongs_to_many :services
+
+  # def display_name
+  #   name.humanize
+  # end
+
+  # def slug
+  #   name.parameterize
+  # end
+end

--- a/app/models/directory.rb
+++ b/app/models/directory.rb
@@ -1,12 +1,6 @@
 class Directory < ApplicationRecord
   has_and_belongs_to_many :services
+  has_and_belongs_to_many :taxonomies
   validates_presence_of :name, :label
   validates_uniqueness_of :name, :label
-  # def display_name
-  #   name.humanize
-  # end
-
-  # def slug
-  #   name.parameterize
-  # end
 end

--- a/app/models/directory_service.rb
+++ b/app/models/directory_service.rb
@@ -1,0 +1,4 @@
+class DirectoryService < ApplicationRecord
+  belongs_to :service
+  belongs_to :directory
+end

--- a/app/models/directory_taxonomy.rb
+++ b/app/models/directory_taxonomy.rb
@@ -1,0 +1,4 @@
+class DirectoryTaxonomy < ApplicationRecord
+  belongs_to :taxonomy
+  belongs_to :directory
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -49,6 +49,8 @@ class Service < ApplicationRecord
   has_many :service_taxonomies, dependent: :destroy
   has_many :taxonomies, -> { distinct }, through: :service_taxonomies
 
+  has_and_belongs_to_many :directories
+
   has_many :watches
   has_many :users, through: :watches
 
@@ -64,14 +66,14 @@ class Service < ApplicationRecord
   has_one :last_version, -> { order(created_at: :desc) }, class_name: 'ServiceVersion', as: :item
   scope :with_last_version, -> { includes(last_version: [user: :watches]) }
 
-  scope :in_directory, -> (directory) { where("directories &&  ?", "{#{directory}}" ) }
+  scope :in_directory, -> (directory) { Directory.where(name: directory).first.services }
 
 
   # callbacks
   after_save :notify_watchers
   after_save :add_parent_taxonomies
   before_save :skip_nested_indexes
-  before_save :update_directories
+  #before_save :update_directories
 
   filterrific(
     default_filter_params: { sorted_by: "recent" },

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -73,7 +73,7 @@ class Service < ApplicationRecord
   after_save :notify_watchers
   after_save :add_parent_taxonomies
   before_save :skip_nested_indexes
-  #before_save :update_directories
+  before_save :update_directories
 
   filterrific(
     default_filter_params: { sorted_by: "recent" },
@@ -260,11 +260,7 @@ class Service < ApplicationRecord
   end
 
   def update_directories
-    if self.directories_changed?
-      self.directories&.reject!(&:blank?) # this makes sure there's no empty string added to directories array
-      self.directories = self.directories&.uniq
-      self.directories_as_text = self.directories&.sort&.join(", ") # make sure directories always in same order
-    end
+    self.directories_as_text = self.directories&.map{ |dir| dir.name }&.sort&.join(", ")
   end
 
   # include nested taxonomies in json representation by default

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -66,7 +66,7 @@ class Service < ApplicationRecord
   has_one :last_version, -> { order(created_at: :desc) }, class_name: 'ServiceVersion', as: :item
   scope :with_last_version, -> { includes(last_version: [user: :watches]) }
 
-  scope :in_directory, -> (directory) { Directory.where(name: directory).first.services }
+  scope :in_directory, -> (directory) { joins(:directories).where(directories: { name: directory }) }
 
 
   # callbacks

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -22,6 +22,7 @@ class Service < ApplicationRecord
 
   has_and_belongs_to_many :send_needs
   has_and_belongs_to_many :suitabilities
+  has_and_belongs_to_many :directories
 
   has_many :links
   accepts_nested_attributes_for :links, allow_destroy: true, reject_if: :all_blank
@@ -48,8 +49,6 @@ class Service < ApplicationRecord
 
   has_many :service_taxonomies, dependent: :destroy
   has_many :taxonomies, -> { distinct }, through: :service_taxonomies
-
-  has_and_belongs_to_many :directories
 
   has_many :watches
   has_many :users, through: :watches

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -7,6 +7,8 @@ class Taxonomy < ApplicationRecord
     has_many :service_taxonomies, dependent: :destroy
     has_many :services, -> { distinct }, through: :service_taxonomies
 
+    has_and_belongs_to_many :directories
+
     attr_accessor :skip_mongo_callbacks
     after_commit :update_index, if: -> { skip_mongo_callbacks == !true }
     after_commit :trigger_scout_rebuild

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -17,7 +17,7 @@ class Taxonomy < ApplicationRecord
     validates :name, length: { minimum: 2 }
     validates :name, length: { maximum: 100 }
 
-    scope :filter_by_directory, -> (directory) { where(id: joins(:services).merge(Service.in_directory(directory)).distinct) }
+    scope :filter_by_directory, -> (directory) { joins(:directories).where(directories: { name: directory }) }
     
     def slug
         name.parameterize

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -22,9 +22,9 @@ class IndexedServicesSerializer < ActiveModel::Serializer
     :status
 
   has_many :target_directories do 
-    if APP_CONFIG["directories"].present?
+    if Directory.any?
       object.directories.map do |directory|
-        { name: directory, label: APP_CONFIG["directories"].find{|d| d["value"] === directory}['label'] }
+        { name: directory, label: directory.label }
       end
     end  
   end

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -22,11 +22,9 @@ class IndexedServicesSerializer < ActiveModel::Serializer
     :status
 
   has_many :target_directories do 
-    if Directory.any?
-      object.directories.map do |directory|
-        { name: directory, label: directory.label }
-      end
-    end  
+    object.directories.map do |directory|
+      { name: directory.name, label: directory.label }
+    end
   end
   
   has_many :locations do

--- a/app/views/admin/services/editors/_directories.html.erb
+++ b/app/views/admin/services/editors/_directories.html.erb
@@ -1,4 +1,4 @@
-<% if APP_CONFIG["directories"].present? %>
+<% if Directory.any? %>
 <section class="directories">
     <fieldset class="field-group field-group--two-cols field-group--no-top-margin margin-bottom">
         <legend class="field-group__legend">Choose which directories this service should appear in</legend>

--- a/app/views/admin/services/editors/_directories.html.erb
+++ b/app/views/admin/services/editors/_directories.html.erb
@@ -1,14 +1,14 @@
 <% if Directory.any? %>
-<section class="directories">
-    <fieldset class="field-group field-group--two-cols field-group--no-top-margin margin-bottom">
-        <legend class="field-group__legend">Choose which directories this service should appear in</legend>
-        <%= s.collection_check_boxes( :directory_ids, Directory.all, :id, :name) do |c| %>
-            <div class="field checkbox checkbox--small ">
-                <%= c.check_box class: "checkbox__input" %>
-                <%= c.label class: "checkbox__label" %>
-            </div>
-        <% end %>
-    </fieldset>
-</section>
+    <section class="directories">
+        <fieldset class="field-group field-group--two-cols field-group--no-top-margin margin-bottom">
+            <legend class="field-group__legend">Choose which directories this service should appear in</legend>
+            <%= s.collection_check_boxes( :directory_ids, Directory.all, :id, :name) do |c| %>
+                <div class="field checkbox checkbox--small ">
+                    <%= c.check_box class: "checkbox__input" %>
+                    <%= c.label class: "checkbox__label" %>
+                </div>
+            <% end %>
+        </fieldset>
+    </section>
 <% end %>
 

--- a/app/views/admin/services/editors/_directories.html.erb
+++ b/app/views/admin/services/editors/_directories.html.erb
@@ -2,7 +2,7 @@
 <section class="directories">
     <fieldset class="field-group field-group--two-cols field-group--no-top-margin margin-bottom">
         <legend class="field-group__legend">Choose which directories this service should appear in</legend>
-        <%= s.collection_check_boxes( :directories, valid_directory_list, :first, :first, {}) do |c| %>
+        <%= s.collection_check_boxes( :directory_ids, Directory.all, :id, :name) do |c| %>
             <div class="field checkbox checkbox--small ">
                 <%= c.check_box class: "checkbox__input" %>
                 <%= c.label class: "checkbox__label" %>

--- a/app/views/admin/taxonomies/_fields.html.erb
+++ b/app/views/admin/taxonomies/_fields.html.erb
@@ -13,3 +13,14 @@
     <p class="field__hint">Override the default sort order. Higher is later.</p>
     <%= s.number_field :sort_order, class: "field__input one-half" %>
 </div>
+
+<div class="field">
+    <%= s.label :directories, class: "field__label" %>
+    <legend class="field-group__legend">Choose which directories this taxonomy should appear in on Scout:</legend>
+    <%= s.collection_check_boxes( :directory_ids, Directory.all, :id, :name) do |c| %>
+        <div class="field checkbox checkbox--small ">
+            <%= c.check_box class: "checkbox__input" %>
+            <%= c.label class: "checkbox__label" %>
+        </div>
+    <% end %>
+</div>

--- a/app/views/shared/_directory-shortcuts.html.erb
+++ b/app/views/shared/_directory-shortcuts.html.erb
@@ -11,21 +11,21 @@
 
     
 
-    <% if APP_CONFIG["directories"].present? %>
+    <% if Directory.any? %>
     <span class="shortcuts__divider">|</span>
 
-            <% APP_CONFIG["directories"].each_with_index do |directory, index| %>
+            <% Directory.all.each_with_index do |directory, index| %>
 
                  <%= render partial: "shared/shortcuts_item", 
                     locals: {
-                        state: params[:directory] === directory["value"], 
-                        link: directory_links[directory["value"]],
-                        count: directory_counts.dig(directory["value"], :all),
-                        label: directory["value"]
+                        state: params[:directory] === directory.name, 
+                        link: directory_links[directory.name],
+                        count: directory_counts.dig(directory.name, :all),
+                        label: directory.name
                     } %>
           
 
-                <% if index != APP_CONFIG["directories"].size-1 %>
+                <% if index != Directory.all.size-1 %>
                     <span class="shortcuts__divider">|</span>
                 <% end %>
             <% end %>

--- a/app/views/shared/_directory-shortcuts.html.erb
+++ b/app/views/shared/_directory-shortcuts.html.erb
@@ -12,24 +12,24 @@
     
 
     <% if Directory.any? %>
-    <span class="shortcuts__divider">|</span>
+        <span class="shortcuts__divider">|</span>
 
-            <% Directory.all.each_with_index do |directory, index| %>
+                <% Directory.all.each_with_index do |directory, index| %>
 
-                 <%= render partial: "shared/shortcuts_item", 
-                    locals: {
-                        state: params[:directory] === directory.name, 
-                        link: directory_links[directory.name],
-                        count: directory_counts.dig(directory.name, :all),
-                        label: directory.name
-                    } %>
-          
+                    <%= render partial: "shared/shortcuts_item",
+                        locals: {
+                            state: params[:directory] === directory.name,
+                            link: directory_links[directory.name],
+                            count: directory_counts.dig(directory.name, :all),
+                            label: directory.name
+                        } %>
 
-                <% if index != Directory.all.size-1 %>
-                    <span class="shortcuts__divider">|</span>
+
+                    <% if index != Directory.all.size-1 %>
+                        <span class="shortcuts__divider">|</span>
+                    <% end %>
                 <% end %>
-            <% end %>
-        <br />
+            <br />
         <% end %>
 
 

--- a/app/views/shared/_services-nav.html.erb
+++ b/app/views/shared/_services-nav.html.erb
@@ -1,9 +1,9 @@
 <% 
     @directory_links = {}
 
-    if APP_CONFIG["directories"].present?
-      APP_CONFIG["directories"].each do |directory|
-        @directory_links[directory["value"]] = admin_services_path(directory: directory["value"]);
+    if Directory.any?
+      Directory.all.each do |directory|
+        @directory_links[directory.name] = admin_services_path(directory: directory.name);
       end
     end
 

--- a/app/views/shared/_services-nav.html.erb
+++ b/app/views/shared/_services-nav.html.erb
@@ -1,10 +1,8 @@
 <% 
     @directory_links = {}
 
-    if Directory.any?
-      Directory.all.each do |directory|
-        @directory_links[directory.name] = admin_services_path(directory: directory.name);
-      end
+    Directory.all.each do |directory|
+      @directory_links[directory.name] = admin_services_path(directory: directory.name);
     end
 
 %>

--- a/app/views/shared/_taxonomies-nav.html.erb
+++ b/app/views/shared/_taxonomies-nav.html.erb
@@ -1,9 +1,9 @@
 <% 
     @directory_links = {}
 
-    if APP_CONFIG["directories"].present?
-      APP_CONFIG["directories"].each do |directory|
-        @directory_links[directory["value"]] = admin_taxonomies_path(directory: directory["value"]);
+    if Directory.any?
+      Directory.all.each do |directory|
+        @directory_links[directory.name] = admin_taxonomies_path(directory: directory.name);
       end
     end
 %>

--- a/app/views/shared/_users-nav.html.erb
+++ b/app/views/shared/_users-nav.html.erb
@@ -1,10 +1,8 @@
 <% 
     @directory_links = {}
 
-    if Directory.any?
-      Directory.all.each do |directory|
-        @directory_links[directory.name] = admin_users_path(directory: directory.name);
-      end
+    Directory.all.each do |directory|
+      @directory_links[directory.name] = admin_users_path(directory: directory.name);
     end
 
 %>

--- a/app/views/shared/_users-nav.html.erb
+++ b/app/views/shared/_users-nav.html.erb
@@ -1,9 +1,9 @@
 <% 
     @directory_links = {}
 
-    if APP_CONFIG["directories"].present?
-      APP_CONFIG["directories"].each do |directory|
-        @directory_links[directory["value"]] = admin_users_path(directory: directory["value"]);
+    if Directory.any?
+      Directory.all.each do |directory|
+        @directory_links[directory.name] = admin_users_path(directory: directory.name);
       end
     end
 

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -2,8 +2,8 @@ default:
   title: Outpost
 buckinghamshire:
   title: Manage directory listing
-  directories:
-    - value: Family Information Service
-      label: bfis
-    - value: Buckinghamshire Online Directory
-      label: bod
+  # directories:
+  #   - value: Family Information Service
+  #     label: bfis
+  #   - value: Buckinghamshire Online Directory
+  #     label: bod

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -2,8 +2,3 @@ default:
   title: Outpost
 buckinghamshire:
   title: Manage directory listing
-  # directories:
-  #   - value: Family Information Service
-  #     label: bfis
-  #   - value: Buckinghamshire Online Directory
-  #     label: bod

--- a/db/migrate/20210910115333_create_directories.rb
+++ b/db/migrate/20210910115333_create_directories.rb
@@ -1,0 +1,12 @@
+class CreateDirectories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :directories do |t|
+      t.string :name
+      t.string :label
+
+      t.timestamps
+    end
+
+    create_join_table(:services, :directories)
+  end
+end

--- a/db/migrate/20210910133315_drop_directories_field_from_services.rb
+++ b/db/migrate/20210910133315_drop_directories_field_from_services.rb
@@ -1,0 +1,7 @@
+
+
+class DropDirectoriesFieldFromServices < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :services, :directories
+  end
+end

--- a/db/migrate/20210910164039_create_directory_taxonomies.rb
+++ b/db/migrate/20210910164039_create_directory_taxonomies.rb
@@ -1,0 +1,5 @@
+class CreateDirectoryTaxonomies < ActiveRecord::Migration[6.0]
+  def change
+    create_join_table(:taxonomies, :directories)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_03_151205) do
+ActiveRecord::Schema.define(version: 2021_09_10_133315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -67,6 +67,18 @@ ActiveRecord::Schema.define(version: 2021_09_03_151205) do
     t.bigint "custom_field_section_id", null: false
     t.string "options"
     t.index ["custom_field_section_id"], name: "index_custom_fields_on_custom_field_section_id"
+  end
+
+  create_table "directories", force: :cascade do |t|
+    t.string "name"
+    t.string "label"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "directories_services", id: false, force: :cascade do |t|
+    t.bigint "service_id", null: false
+    t.bigint "directory_id", null: false
   end
 
   create_table "feedbacks", force: :cascade do |t|
@@ -299,7 +311,6 @@ ActiveRecord::Schema.define(version: 2021_09_03_151205) do
     t.boolean "age_band_all"
     t.string "old_open_objects_external_id"
     t.boolean "temporarily_closed"
-    t.text "directories", default: [], array: true
     t.text "directories_as_text"
     t.index ["discarded_at"], name: "index_services_on_discarded_at"
     t.index ["ofsted_item_id"], name: "index_services_on_ofsted_item_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_10_133315) do
+ActiveRecord::Schema.define(version: 2021_09_10_164039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -78,6 +78,11 @@ ActiveRecord::Schema.define(version: 2021_09_10_133315) do
 
   create_table "directories_services", id: false, force: :cascade do |t|
     t.bigint "service_id", null: false
+    t.bigint "directory_id", null: false
+  end
+
+  create_table "directories_taxonomies", id: false, force: :cascade do |t|
+    t.bigint "taxonomy_id", null: false
     t.bigint "directory_id", null: false
   end
 

--- a/features/admin_manage_services.feature
+++ b/features/admin_manage_services.feature
@@ -23,12 +23,12 @@ Feature: Admin manage services
         Then The service should be created
 
     Scenario: Edit an existing service
-        Given A service exists
-        And I am on the admin service page for 'Test service'
+        Given A service exists called 'Reading group' that has one suitability
+        And I am on the admin service page for 'Reading group'
         When I fill in the suitability field with 'Learning difficulties'
         And I update the service
         Then The service should be updated
-        And The service 'Test service' should have two suitabilities
+        And The service 'Reading group' should have two suitabilities
 
     Scenario: Browse services by directory
         Given directories exist

--- a/features/admin_manage_services.feature
+++ b/features/admin_manage_services.feature
@@ -31,7 +31,8 @@ Feature: Admin manage services
         And The service 'Test service' should have two suitabilities
 
     Scenario: Browse services by directory
-        Given 4 services exist in directory 'Family Information Service'
+        Given directories exist
+        And 4 services exist in directory 'Family Information Service'
         And 2 services exist in directory 'Buckinghamshire Online Directory'
         When I am on the admin services page
         And I should see 'All (6)'

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -36,7 +36,7 @@ Given("An organisation exists") do
 end
 
 Given("A service exists") do
-  @organisation = FactoryBot.create(:service, name: "Test service", suitabilities: [Suitability.where(name: 'Autism').first])
+  @service = FactoryBot.create(:service, name: "Test service", suitabilities: [Suitability.where(name: 'Autism').first])
 end
 
 Given("I am on the admin service page for {string}") do |service_name|
@@ -48,6 +48,11 @@ Given("Some options for suitability exist") do
   FactoryBot.create(:suitability, name: 'Learning difficulties')
 end
 
+Given("directories exist") do
+  FactoryBot.create(:directory, name: "Family Information Service", label: "bfis")
+  FactoryBot.create(:directory, name: "Buckinghamshire Online Directory", label: "bod")
+end
+
 Given("{int} services exist in directory {string}") do |number_of_services, directory_name|
-  FactoryBot.create_list(:service, number_of_services, directories: [directory_name])
+  FactoryBot.create_list(:service, number_of_services, directories: [Directory.where(name: directory_name).first])
 end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -35,8 +35,8 @@ Given("An organisation exists") do
   @organisation = FactoryBot.create(:organisation, name: "Test org")
 end
 
-Given("A service exists") do
-  @service = FactoryBot.create(:service, name: "Test service", suitabilities: [Suitability.where(name: 'Autism').first])
+Given("A service exists called {string} that has one suitability") do |service_name|
+  @service = FactoryBot.create(:service, name: service_name, suitabilities: [Suitability.where(name: 'Autism').first])
 end
 
 Given("I am on the admin service page for {string}") do |service_name|

--- a/lib/tasks/data_import/bod/directories.rake
+++ b/lib/tasks/data_import/bod/directories.rake
@@ -1,0 +1,8 @@
+namespace :bod do
+  namespace :directories do
+    task :create => :environment do
+      Directory.create(name: 'Family Information Service', label: 'bfis')
+      Directory.create(name: 'Buckinghamshire Online Directory', label: 'bod')
+    end
+  end
+end

--- a/lib/tasks/data_import/bod/forest_admin.rake
+++ b/lib/tasks/data_import/bod/forest_admin.rake
@@ -5,6 +5,7 @@ namespace :forest_admin do
     start_time = Time.now
     Rake::Task['bod:directories:create'].invoke
     Rake::Task['bod:services:apply_bfis_directory_to_current'].invoke
+    Rake::Task['bod:taxonomy:apply_bfis_directory_to_current'].invoke
     Rake::Task['bod:users:create_users_from_file'].invoke
     Rake::Task['bod:custom_fields:build_initial'].invoke
     Rake::Task['bod:organisations:trim'].invoke

--- a/lib/tasks/data_import/bod/forest_admin.rake
+++ b/lib/tasks/data_import/bod/forest_admin.rake
@@ -3,7 +3,8 @@ namespace :forest_admin do
 
   task :import => :environment do
     start_time = Time.now
-    
+    Rake::Task['bod:directories:create'].invoke
+    Rake::Task['bod:services:apply_bfis_directory_to_current'].invoke
     Rake::Task['bod:users:create_users_from_file'].invoke
     Rake::Task['bod:custom_fields:build_initial'].invoke
     Rake::Task['bod:organisations:trim'].invoke

--- a/lib/tasks/data_import/bod/services.rake
+++ b/lib/tasks/data_import/bod/services.rake
@@ -36,7 +36,7 @@ namespace :bod do
         if exisiting_service.present?
           puts "Service already exists with this name: #{exisiting_service.name}, applying BOD directory"
           exisiting_service.skip_mongo_callbacks = true
-          exisiting_service.update(directories: exisiting_service.directories << "Buckinghamshire Online Directory")
+          exisiting_service.directories << Directory.where(name: "Buckinghamshire Online Directory").first
           next
         end
 
@@ -87,7 +87,7 @@ namespace :bod do
         )
         service.skip_mongo_callbacks = true
 
-        service.update(directories: service.directories << "Buckinghamshire Online Directory")
+        service.directories << Directory.where(name: "Buckinghamshire Online Directory").first
 
         if service.save
           # CUSTOM FIELDS
@@ -261,7 +261,7 @@ namespace :bod do
         if row["Dir"] == "BOD"
           service = Service.find(row["BFIS ID"])
           service.skip_mongo_callbacks = true
-          service.update(directories: service.directories << "Buckinghamshire Online Directory")
+          service.directories << Directory.where(name: "Buckinghamshire Online Directory").first
           unless service.save
             puts "Service #{service.id} failed to save whilst applying BOD directory"
           end
@@ -317,10 +317,10 @@ namespace :bod do
 end
 
 def set_existing_services_as_bfis
-  puts "Applying BFIS directory tag to existing services"
+  puts "Applying BFIS directory existing services"
   Service.all.each do |service|
     service.skip_mongo_callbacks = true
-    service.update(directories: service.directories << "Family Information Service")
+    service.directories << Directory.where(name: "Family Information Service").first
   end
 end
 

--- a/lib/tasks/data_import/bod/taxonomies.rake
+++ b/lib/tasks/data_import/bod/taxonomies.rake
@@ -61,6 +61,18 @@ namespace :bod do
       end
     end
 
+    task :apply_bfis_directory_to_current => :environment do
+      set_existing_taxonomies_as_bfis
+    end
+
+    def set_existing_taxonomies_as_bfis
+      puts "Applying BFIS directory to existing taxonomies"
+      Taxonomy.all.each do |taxonomy|
+        taxonomy.skip_mongo_callbacks = true
+        taxonomy.directories << Directory.where(name: "Family Information Service").first
+      end
+    end
+
     def apply_taxonomies(service, row)
       service.skip_mongo_callbacks = true
       row["Tags"].present? ? taxonomies_to_apply = eval(row["Tags"]) : taxonomies_to_apply = []
@@ -69,6 +81,7 @@ namespace :bod do
 
       taxonomies_to_apply.each do |taxonomy_to_apply|
         taxonomy = Taxonomy.create_with(skip_mongo_callbacks: true).find_or_create_by_path(TAXONOMY_MAPPING[taxonomy_to_apply]) if TAXONOMY_MAPPING[taxonomy_to_apply].present?
+        taxonomy.directories << Directory.where(name: "Buckinghamshire Online Directory").first unless taxonomy.directories.include?(Directory.where(name: "Buckinghamshire Online Directory").first)
         service.taxonomies |= [taxonomy] if taxonomy.present?
       end
 

--- a/lib/tasks/data_import/bod/taxonomies.rake
+++ b/lib/tasks/data_import/bod/taxonomies.rake
@@ -81,10 +81,13 @@ namespace :bod do
 
       taxonomies_to_apply.each do |taxonomy_to_apply|
         taxonomy = Taxonomy.create_with(skip_mongo_callbacks: true).find_or_create_by_path(TAXONOMY_MAPPING[taxonomy_to_apply]) if TAXONOMY_MAPPING[taxonomy_to_apply].present?
-        taxonomy.directories << Directory.where(name: "Buckinghamshire Online Directory").first unless taxonomy.directories.include?(Directory.where(name: "Buckinghamshire Online Directory").first)
-        service.taxonomies |= [taxonomy] if taxonomy.present?
+        if taxonomy.present?
+          taxonomy.directories << Directory.where(name: "Buckinghamshire Online Directory").first unless taxonomy.directories.include?(Directory.where(name: "Buckinghamshire Online Directory").first)
+          service.taxonomies |= [taxonomy] if taxonomy.present?
+        else
+          puts "Taxonomy not found in mapping: #{taxonomy_to_apply}"
+        end
       end
-
       puts "applied taxonomies #{service.taxonomies.inspect} to service #{service.name}"
       puts "failed to save service #{service.name}" unless service.save
     end

--- a/spec/factories/directory.rb
+++ b/spec/factories/directory.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :directory do
+  end
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -12,21 +12,21 @@ RSpec.describe Service, type: :model do
     it 'should populate service taxonomy roots on save' do
       root_taxonomy = Taxonomy.create({ name: 'Root' })
       child1_taxonomy = Taxonomy.create({ name: 'Child 1', parent: root_taxonomy })
-      @service = Service.create!({ organisation: @organisation, name: 'Test Service', description: "Test service description", taxonomies: [child1_taxonomy] })
+      @service = Service.create!({ organisation: @organisation, name: 'Test Service 001', description: "Test service description", taxonomies: [child1_taxonomy] })
       expect(@service.reload.taxonomies).to match_array([root_taxonomy, child1_taxonomy])
     end
 
     it 'should not remove taxonomy roots if they were passed as params' do
       root_taxonomy = Taxonomy.create({ name: 'Root' })
       child1_taxonomy = Taxonomy.create({ name: 'Child 1', parent: root_taxonomy })
-      @service = Service.create!({ organisation: @organisation, name: 'Test Service', description: "Test service description", taxonomies: [root_taxonomy, child1_taxonomy] })
+      @service = Service.create!({ organisation: @organisation, name: 'Test Service 002', description: "Test service description", taxonomies: [root_taxonomy, child1_taxonomy] })
       expect(@service.reload.taxonomies).to match_array([root_taxonomy, child1_taxonomy])
     end
 
     it 'should not create additional root service taxonomy relations on subsequent saves' do
       root_taxonomy = Taxonomy.create({ name: 'Root' })
       child1_taxonomy = Taxonomy.create({ name: 'Child 1', parent: root_taxonomy })
-      @service = Service.create!({ organisation: @organisation, name: 'Test Service', description: "Test service description", taxonomies: [root_taxonomy, child1_taxonomy] })
+      @service = Service.create!({ organisation: @organisation, name: 'Test Service 003', description: "Test service description", taxonomies: [root_taxonomy, child1_taxonomy] })
       expect(ServiceTaxonomy.where(service_id: @service.id).count).to eq(2)
       @service.save
       expect(ServiceTaxonomy.where(service_id: @service.id).count).to eq(2)

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -53,9 +53,12 @@ RSpec.describe Service, type: :model do
 
   describe '#in_directory' do
     it 'should return services that are in specified directory' do
-      @services_directory_a = FactoryBot.create_list(:service, 3, organisation: @organisation, directories: ['Directory A'])
-      @services_directory_b = FactoryBot.create_list(:service, 4, organisation: @organisation, directories: ['Directory B'])
-      @services_directory_c = FactoryBot.create_list(:service, 2, organisation: @organisation, directories: ['Directory B', 'Directory A'])
+      @directory_a = FactoryBot.create(:directory, name: "Directory A", label: "a")
+      @directory_b = FactoryBot.create(:directory, name: "Directory B", label: "b")
+
+      @services_directory_a = FactoryBot.create_list(:service, 3, organisation: @organisation, directories: [@directory_a])
+      @services_directory_b = FactoryBot.create_list(:service, 4, organisation: @organisation, directories: [@directory_b])
+      @services_directory_c = FactoryBot.create_list(:service, 2, organisation: @organisation, directories: [@directory_a, @directory_b])
 
       expect(Service.in_directory('Directory A').count).to eq(5)
       expect(Service.in_directory('Directory B').count).to eq(6)

--- a/spec/models/taxonomy_spec.rb
+++ b/spec/models/taxonomy_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe Taxonomy, type: :model do
 
   describe '#filter_by_directory' do
     it 'should return taxonomies that are in specified directory' do
-      @taxonomy_a = FactoryBot.create(:taxonomy)
-      @taxonomy_b = FactoryBot.create(:taxonomy)
-      @taxonomy_c = FactoryBot.create(:taxonomy)
+      @directory_a = FactoryBot.create(:directory, name: "Directory A", label: "a")
+      @directory_b = FactoryBot.create(:directory, name: "Directory B", label: "b")
 
-      @services = FactoryBot.create_list(:service, 3, organisation: @organisation, taxonomies: [@taxonomy_a, @taxonomy_b], directories: ['Directory A'])
-      @services = FactoryBot.create_list(:service, 5, organisation: @organisation, taxonomies: [@taxonomy_c], directories: ['Directory B'])
+      @taxonomy_a = FactoryBot.create(:taxonomy, directories: [@directory_a])
+      @taxonomy_b = FactoryBot.create(:taxonomy, directories: [@directory_a])
+      @taxonomy_c = FactoryBot.create(:taxonomy, directories: [@directory_b])
 
       expect(Taxonomy.filter_by_directory('Directory A').count).to eq(2)
       expect(Taxonomy.filter_by_directory('Directory A')).to include(@taxonomy_a, @taxonomy_b)

--- a/spec/requests/api/get_taxonomies_spec.rb
+++ b/spec/requests/api/get_taxonomies_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+describe 'GET taxonomies endpoint', type: :request do
+  let!(:root_taxonomy) { FactoryBot.create(:taxonomy) }
+  let!(:taxonomy_a) { FactoryBot.create(:taxonomy, name: 'category a', parent_id: root_taxonomy.id) } 
+  let!(:taxonomy_b) { FactoryBot.create(:taxonomy, name: 'category b', parent_id: root_taxonomy.id) }
+
+  it 'returns taxonomies' do
+    get "/api/v1/taxonomies"
+    response_body = JSON.parse(response.body)
+
+    root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
+    expect(root_taxonomy_ids).to match_array([root_taxonomy.id])
+
+    root_taxonomy_names = response_body.map{|taxonomy| taxonomy["label"]}
+    expect(root_taxonomy_names).to match_array([root_taxonomy.name])
+
+    child_taxonomies = response_body.first['children'].map{|t| t['label']}
+    expect(child_taxonomies).to match_array([taxonomy_a.name, taxonomy_b.name])
+  end
+
+  context 'with directories in the DB' do
+    let!(:directory_a) { FactoryBot.create(:directory, name: "Directory A", label: "a") }
+    let!(:directory_b) { FactoryBot.create(:directory, name: "Directory B", label: "b") }
+
+    let!(:directory_b_taxonomy) { FactoryBot.create(:taxonomy, directories: [directory_b]) }
+
+    before do
+      root_taxonomy.update(directories: [directory_a])
+      taxonomy_a.update(directories: [directory_a])
+      taxonomy_b.update(directories: [directory_a])
+    end
+
+    it 'can filter by directory' do
+      get "/api/v1/taxonomies?directory=#{directory_a.label}"
+      response_body = JSON.parse(response.body)
+
+      root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
+      expect(root_taxonomy_ids).to match_array([root_taxonomy.id])
+
+      get "/api/v1/taxonomies?directory=#{directory_b.label}"
+      response_body = JSON.parse(response.body)
+
+      root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
+      expect(root_taxonomy_ids).to match_array([directory_b_taxonomy.id])
+    end
+  end
+end


### PR DESCRIPTION
Updating directories to be an actual DB table rather than configured in a file. This allows for taxonomies to be associated with directories as well as services.

I’ve set up the relationships as HABTM for now, which does the job, but perhaps it should be has_many though.. or even a polymorphic relationship might be more flexible going forward. But shouldn’t be too hard to change further down the line if needed

Have also added interfaces for editing taxonomies directories as shown in screenshow below. This allows admin users to choose which taxonomies should appear as categories on their respective Scout directory

![Screenshot 2021-09-13 at 10 19 45](https://user-images.githubusercontent.com/5345477/133058433-b41ba2c1-8843-41e0-a62d-f76d23ad1624.png)
