### PR TITLE
Multiple Scout build hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ It will be on `localhost:3000`. You can log in with `example@example.com` and th
 
 To see multiple directories in Outpost, you'll need to create some directoires in the database. You can run `rake bod:directories:create` or create some manually like so:
 ```
-Directory.create(name: "Family Information Service', label: 'bfis', scout_build_hook: 'http://buidl_hook_url')
+Directory.create(name: 'Family Information Service', label: 'bfis', scout_build_hook: 'http://buidl_hook_url')
 ```
 
 You can also make per instance configurations in config/app_config.yml and then set the `INSTANCE` .env variable or run the app with:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ It will be on `localhost:3000`. You can log in with `example@example.com` and th
 
 ### With multiple directories
 
-To see multiple directories in Outpost, run the app with:
+To see multiple directories in Outpost, you'll need to create some directoires in the database. You can run `rake bod:directories:create` or create some manually like so:
+```
+Directory.create(name: "Family Information Service', label: 'bfis')
+```
+
+You can also make per instance configurations in config/app_config.yml and then set the `INSTANCE` .env variable or run the app with:
 
 ```
 INSTANCE=buckinghamshire rails s

--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ It will be on `localhost:3000`. You can log in with `example@example.com` and th
 
 ### With multiple directories
 
+You can have multiple directories configured within a single instance of Outpost. This allows for separate Scout instances to be powered by each directory.
+
+Services can be associated with directories, and then Scout will pull through the relevant services.
+
+Taxonomies can also be associated with directories, which will affect what categories are shown on the respective Scout instance.
+
 To see multiple directories in Outpost, you'll need to create some directoires in the database. You can run `rake bod:directories:create` or create some manually like so:
 ```
 Directory.create(name: 'Family Information Service', label: 'bfis', scout_build_hook: 'http://build_hook_url')
@@ -73,10 +79,7 @@ You can also make per instance configurations in config/app_config.yml and then 
 INSTANCE=buckinghamshire rails s
 ```
 
-This will start the app with the directories listed in `config/app_config.yaml`.
-
-To add more directories, or set up another instance with separate directories,
-edit `config/app_config.yaml`.
+This will start the app with the configuration in `config/app_config.yaml`.
 
 ### With Docker
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ It will be on `localhost:3000`. You can log in with `example@example.com` and th
 
 To see multiple directories in Outpost, you'll need to create some directoires in the database. You can run `rake bod:directories:create` or create some manually like so:
 ```
-Directory.create(name: "Family Information Service', label: 'bfis')
+Directory.create(name: "Family Information Service', label: 'bfis', scout_build_hook: 'http://buidl_hook_url')
 ```
 
 You can also make per instance configurations in config/app_config.yml and then set the `INSTANCE` .env variable or run the app with:
@@ -134,7 +134,6 @@ It needs the following extra environment variables to be set:
 | `DB_URI`                                        | the MongoDB database for the public index                                                                                 | mongodb://user:password<br/>@example.com/database       | Yes, if using the API service                     |
 | `INITIAL_ADMIN_PASSWORD`                        | an initial admin password to log in with for local development                                                            |                                                         | Locally only                                      |
 | `SHOW_ENV_BANNER`                               | show a bright warning banner on non-production environments                                                               | staging                                                 | Only to warn about non-production environments    |
-| `SCOUT_BUILD_HOOK`                              | Outpost will make a POST request to this webhook URL whenever taxonomies are changed. Intended to trigger Scout rebuilds. |                                                         | No                                                |
 
 ## 🔐 OAuth provider
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ It will be on `localhost:3000`. You can log in with `example@example.com` and th
 
 To see multiple directories in Outpost, you'll need to create some directoires in the database. You can run `rake bod:directories:create` or create some manually like so:
 ```
-Directory.create(name: 'Family Information Service', label: 'bfis', scout_build_hook: 'http://buidl_hook_url')
+Directory.create(name: 'Family Information Service', label: 'bfis', scout_build_hook: 'http://build_hook_url')
 ```
 
 You can also make per instance configurations in config/app_config.yml and then set the `INSTANCE` .env variable or run the app with:

--- a/app/jobs/trigger_scout_rebuild_job.rb
+++ b/app/jobs/trigger_scout_rebuild_job.rb
@@ -2,8 +2,8 @@ class TriggerScoutRebuildJob < ApplicationJob
     queue_as :default
   
     def perform()
-        if ENV["SCOUT_BUILD_HOOK"]
-            HTTParty.post(ENV["SCOUT_BUILD_HOOK"])
+        Directory.all.each do |directory|
+            HTTParty.post(directory.scout_build_hook) if directory.scout_build_hook.present?
         end
     end
 end

--- a/db/migrate/20210914134656_add_scout_build_hook_to_directories.rb
+++ b/db/migrate/20210914134656_add_scout_build_hook_to_directories.rb
@@ -1,0 +1,5 @@
+class AddScoutBuildHookToDirectories < ActiveRecord::Migration[6.0]
+  def change
+    add_column :directories, :scout_build_hook, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2021_09_14_144638) do
     t.string "label"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "scout_build_hook"
   end
 
   create_table "directories_services", id: false, force: :cascade do |t|


### PR DESCRIPTION
Add scout build hook field to directories and update job so that multiple Scouts can be updated rather than just one.

Won't need `SCOUT_BUILD_HOOK` environment variable after this.