### PR TITLE
Permanent deletions: don't error when there is a user with notes

### DIFF
--- a/lib/tasks/process_permanent_deletions.rake
+++ b/lib/tasks/process_permanent_deletions.rake
@@ -1,25 +1,30 @@
+desc 'Process permanents deletions'
 task :process_permanent_deletions => :environment  do
-    destroyed_services_count = 0
-    destroyed_users_count = 0
+  destroyed_services_count = 0
+  destroyed_users_count = 0
 
-    Service.discarded.each do |s|
-      service_id = s.id
-      next unless s.marked_for_deletion
-      next unless s.marked_for_deletion <= DateTime.now.beginning_of_day - 30.days
-      s.destroy_associated_data
-      s.destroy
-      puts "Destroyed service #{service_id} and dependents"
-      destroyed_services_count += 1
+  Service.discarded.each do |s|
+    service_id = s.id
+    next unless s.marked_for_deletion
+    next unless s.marked_for_deletion <= DateTime.now.beginning_of_day - 30.days
+    s.destroy_associated_data
+    s.destroy
+    puts "Destroyed service #{service_id} and dependents"
+    destroyed_services_count += 1
+  end
+
+  User.discarded.each do |u|
+    user_id = u.id
+    next unless u.marked_for_deletion
+    next unless u.marked_for_deletion <= DateTime.now.beginning_of_day - 30.days
+    if u.notes.any?
+      puts "Unable to delete user #{user_id} because of associated notes, skipping"
+      next
     end
+    u.destroy
+    puts "Destroyed user #{user_id}"
+    destroyed_users_count += 1
+  end
 
-    User.discarded.each do |u|
-      user_id = u.id
-      next unless u.marked_for_deletion
-      next unless u.marked_for_deletion <= DateTime.now.beginning_of_day - 30.days
-      u.destroy
-      puts "Destroyed user #{user_id}"
-      destroyed_users_count += 1
-    end
-
-    puts "Destroyed #{destroyed_services_count} services and #{destroyed_users_count} users"
+  puts "Destroyed #{destroyed_services_count} services and #{destroyed_users_count} users"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,4 +106,15 @@ RSpec.configure do |config|
     @mongo_client_class = class_double(Mongo::Client).as_stubbed_const
     allow(@mongo_client_class).to receive(:new).and_return(@mongo_client_instance)
   end
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
 end

--- a/spec/tasks/process_permanent_deletions_spec.rb
+++ b/spec/tasks/process_permanent_deletions_spec.rb
@@ -2,36 +2,40 @@ require "rails_helper"
 Rails.application.load_tasks
 
 describe "process permanent deletions" do
+  let(:organisation) { FactoryBot.create(:organisation) }
+  let(:services) { FactoryBot.create_list(:service_with_all_associations, 3, organisation: organisation) }
+  let(:service_for_deletion) { services.last }
 
   before do
-    @organisation = FactoryBot.create(:organisation)
-    @services = FactoryBot.create_list(:service_with_all_associations, 3, organisation: @organisation)
-    @service_for_deletion = @services.last
-    @service_for_deletion.update(discarded_at: Time.now - 40.days, marked_for_deletion: Time.now - 31.days)
-    @service_for_deletion.reload
+    service_for_deletion.update(discarded_at: Time.now - 40.days, marked_for_deletion: Time.now - 31.days)
+    service_for_deletion.reload
+  end
+
+  after(:each) do
+    Rake::Task["process_permanent_deletions"].reenable
   end
 
   it "deletes services and associations" do
-    send_need_1 = @service_for_deletion.send_needs.first
-    send_need_2 = @service_for_deletion.send_needs.last
+    send_need_1 = service_for_deletion.send_needs.first
+    send_need_2 = service_for_deletion.send_needs.last
 
     send_need_1_service_count = send_need_1.services.count
     send_need_2_service_count = send_need_2.services.count
 
-    service_at_location = @service_for_deletion.service_at_locations.first
-    service_link = @service_for_deletion.links.last
-    service_meta = @service_for_deletion.meta.first
-    service_cost_option = @service_for_deletion.cost_options.last
-    service_reg_sched = @service_for_deletion.regular_schedules.first
-    service_contact = @service_for_deletion.contacts.first
-    service_feedback = @service_for_deletion.feedbacks.first
-    service_taxonomy = @service_for_deletion.service_taxonomies.first
-    service_watch = @service_for_deletion.watches.first
-    service_note = @service_for_deletion.notes.first
-    service_local_offer = @service_for_deletion.local_offer
+    service_at_location = service_for_deletion.service_at_locations.first
+    service_link = service_for_deletion.links.last
+    service_meta = service_for_deletion.meta.first
+    service_cost_option = service_for_deletion.cost_options.last
+    service_reg_sched = service_for_deletion.regular_schedules.first
+    service_contact = service_for_deletion.contacts.first
+    service_feedback = service_for_deletion.feedbacks.first
+    service_taxonomy = service_for_deletion.service_taxonomies.first
+    service_watch = service_for_deletion.watches.first
+    service_note = service_for_deletion.notes.first
+    service_local_offer = service_for_deletion.local_offer
 
     Rake::Task["process_permanent_deletions"].invoke
-    expect { @service_for_deletion.reload }.to raise_error ActiveRecord::RecordNotFound
+    expect { service_for_deletion.reload }.to raise_error ActiveRecord::RecordNotFound
     expect { service_at_location.reload }.to raise_error ActiveRecord::RecordNotFound
     expect { service_link.reload }.to raise_error ActiveRecord::RecordNotFound
     expect { service_meta.reload }.to raise_error ActiveRecord::RecordNotFound
@@ -48,5 +52,22 @@ describe "process permanent deletions" do
 
     expect(send_need_1.services.count).to eq(send_need_1_service_count - 1)
     expect(send_need_2.services.count).to eq(send_need_2_service_count - 1)
+  end
+
+  describe 'deleting users that have created notes' do
+    let(:users_for_deletion) { FactoryBot.create_list(:user, 5, discarded_at: Time.now - 40.days, marked_for_deletion: Time.now - 31.days) }
+    let(:user_with_note) { users_for_deletion.first }
+
+    before do
+      user_with_note.notes.create!(service: services.first, body: 'This is a note')
+    end
+
+    it 'deletes the users and does not error' do
+      users_count = User.all.count
+      Rake::Task["process_permanent_deletions"].invoke
+      # Only 4 should be deleted until we decide what to do with deleted users
+      # with notes
+      expect(User.all.count).to eq(users_count - 4)
+    end
   end
 end

--- a/spec/tasks/process_permanent_deletions_spec.rb
+++ b/spec/tasks/process_permanent_deletions_spec.rb
@@ -41,11 +41,12 @@ describe "process permanent deletions" do
     expect { service_feedback.reload }.to raise_error ActiveRecord::RecordNotFound
     expect { service_taxonomy.reload }.to raise_error ActiveRecord::RecordNotFound
     expect { service_watch.reload }.to raise_error ActiveRecord::RecordNotFound
+    expect { service_note.reload }.to raise_error ActiveRecord::RecordNotFound
     expect { service_local_offer.reload }.to raise_error ActiveRecord::RecordNotFound
 
     expect(Service.all.count).to eq(2)
 
     expect(send_need_1.services.count).to eq(send_need_1_service_count - 1)
-    expect(send_need_2.services.count).to eq(send_need_1_service_count - 1)
+    expect(send_need_2.services.count).to eq(send_need_2_service_count - 1)
   end
 end


### PR DESCRIPTION
We haven't come to a solution for these users yet, but while we're working on a fix let's not have the whole rake task error when it encounters one of these users.

This PR also fixes the test file for the rake task which wasn't running due to a mistake in the filename, and adds DatabaseCleaner config for RSpec which should help make the rake task test more reliable.