### PR TITLE
Support/rename service button

### DIFF
--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -44,6 +44,13 @@
         <% end %>
       </tbody>
   </table>
+
+  <% if @services.count > 0 %>
+    <div class="actions">
+      <%= link_to "Add Service, Event or Activity", new_service_path, class: "button button--add"%>
+      <%= link_to "Edit organisation name", edit_organisation_path(@organisation), class: "button button--secondary" %>
+    </div>
+  <% end %>
 <% else %>
   <p class="no-results">You don't have any services listed yet. Start by <strong><%= link_to "adding one", new_service_path %></strong>.</p>
 <% end %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -12,7 +12,7 @@
 
 <h2 class="page-subheading">Your services</h2>
 <div class="actions">
-  <%= link_to "Add service", new_service_path, class: "button button--add"%>
+  <%= link_to "Add Service, Event or Activity", new_service_path, class: "button button--add"%>
   <%= link_to "Edit organisation name", edit_organisation_path(@organisation), class: "button button--secondary" %>
 </div>
 <% if @services.present? %>

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -45,7 +45,7 @@
       </tbody>
   </table>
 
-  <% if @services.count > 0 %>
+  <% if @services.length > 20 %>
     <div class="actions">
       <%= link_to "Add Service, Event or Activity", new_service_path, class: "button button--add"%>
       <%= link_to "Edit organisation name", edit_organisation_path(@organisation), class: "button button--secondary" %>

--- a/spec/features/community_user_managing_services_spec.rb
+++ b/spec/features/community_user_managing_services_spec.rb
@@ -16,7 +16,7 @@ feature 'Community user managing services', type: :feature do
   end
 
   scenario 'I can add a service to the directory' do
-    click_link_or_button('Add service')
+    click_link_or_button('Add Service, Event or Activity')
 
     fill_in('What is your service or activity called?', with: 'Example service')
     fill_in('Describe your service', with: 'Example description here')


### PR DESCRIPTION
1. Renamed + service to + new service, event or activity
![image](https://user-images.githubusercontent.com/649148/153264680-49ee4541-6ed8-4d00-a83b-70aecd3085b1.png)

2. controversial - I have repeated the action buttons below the list of services if you have > 20 services. This only affects 13 organisations.
![image](https://user-images.githubusercontent.com/649148/153264706-6020a588-5243-4100-8abb-bdda556ee7e5.png)

`select organisation_id, count(name) as cnt from services group by organisation_id order by cnt DESC;`
