### PR TITLE
show all labels alphabetically

### DIFF
--- a/app/controllers/admin/labels_controller.rb
+++ b/app/controllers/admin/labels_controller.rb
@@ -1,6 +1,6 @@
 class Admin::LabelsController < Admin::BaseController
     def index
-        @labels = ActsAsTaggableOn::Tag.joins(:taggings).where(taggings: { context: 'labels' }).distinct.most_used(100)
+        @labels = ActsAsTaggableOn::Tag.joins(:taggings).where(taggings: { context: 'labels' }).distinct.sort_by {|tags| -tags.name}
     end
 
     def destroy

--- a/app/controllers/admin/labels_controller.rb
+++ b/app/controllers/admin/labels_controller.rb
@@ -1,6 +1,6 @@
 class Admin::LabelsController < Admin::BaseController
     def index
-        @labels = ActsAsTaggableOn::Tag.joins(:taggings).where(taggings: { context: 'labels' }).distinct.sort_by {|tags| -tags.name}
+        @labels = ActsAsTaggableOn::Tag.joins(:taggings).where(taggings: { context: 'labels' }).distinct.order(:name)
     end
 
     def destroy

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -154,7 +154,7 @@ class Service < ApplicationRecord
   end
 
   def self.options_for_labels
-    ActsAsTaggableOn::Tag.most_used.map { |t| [t.name, t.name] }.unshift(["All labels", ""])
+    ActsAsTaggableOn::Tag.distinct.sort_by {|tags| -tags.name}.map { |t| [t.name, t.name] }.unshift(["All labels", ""])
   end
 
   def validate_ages

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -154,7 +154,7 @@ class Service < ApplicationRecord
   end
 
   def self.options_for_labels
-    ActsAsTaggableOn::Tag.distinct.order(:name).map { |t| [t.name, t.name] }.unshift(["All labels", ""])
+    ActsAsTaggableOn::Tag.order(:name).map { |t| [t.name, t.name] }.unshift(["All labels", ""])
   end
 
   def validate_ages

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -154,7 +154,7 @@ class Service < ApplicationRecord
   end
 
   def self.options_for_labels
-    ActsAsTaggableOn::Tag.distinct.sort_by {|tags| -tags.name}.map { |t| [t.name, t.name] }.unshift(["All labels", ""])
+    ActsAsTaggableOn::Tag.distinct.order(:name).map { |t| [t.name, t.name] }.unshift(["All labels", ""])
   end
 
   def validate_ages

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,7 +76,7 @@ class User < ApplicationRecord
   end
 
   def self.options_for_labels
-    ActsAsTaggableOn::Tag.most_used.map { |t| [t.name, t.name] }.unshift(["All labels", ""])
+    ActsAsTaggableOn::Tag.distinct.sort_by {|tags| -tags.name}.map { |t| [t.name, t.name] }.unshift(["All labels", ""])
   end
 
   # Include default devise modules. Others available are:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,7 +76,7 @@ class User < ApplicationRecord
   end
 
   def self.options_for_labels
-    ActsAsTaggableOn::Tag.distinct.order(:name).map { |t| [t.name, t.name] }.unshift(["All labels", ""])
+    ActsAsTaggableOn::Tag.order(:name).map { |t| [t.name, t.name] }.unshift(["All labels", ""])
   end
 
   # Include default devise modules. Others available are:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,7 +76,7 @@ class User < ApplicationRecord
   end
 
   def self.options_for_labels
-    ActsAsTaggableOn::Tag.distinct.sort_by {|tags| -tags.name}.map { |t| [t.name, t.name] }.unshift(["All labels", ""])
+    ActsAsTaggableOn::Tag.distinct.order(:name).map { |t| [t.name, t.name] }.unshift(["All labels", ""])
   end
 
   # Include default devise modules. Others available are:

--- a/app/views/admin/services/editors/_labels.html.erb
+++ b/app/views/admin/services/editors/_labels.html.erb
@@ -6,7 +6,7 @@
     </div>
 
     <script>
-        __LABELS__=<%= raw ActsAsTaggableOn::Tag.most_used.to_json %>
+        __LABELS__=<%= raw ActsAsTaggableOn::Tag.distinct.to_json %>
     </script>
 
 </section>

--- a/app/views/admin/services/editors/_labels.html.erb
+++ b/app/views/admin/services/editors/_labels.html.erb
@@ -6,7 +6,7 @@
     </div>
 
     <script>
-        __LABELS__=<%= raw ActsAsTaggableOn::Tag.distinct.to_json %>
+        __LABELS__=<%= raw ActsAsTaggableOn::Tag.all.to_json %>
     </script>
 
 </section>


### PR DESCRIPTION
Currently on outpost we only show the most_used labels in filters, the labels page and within the add/edit page.

I'm not sure why this was done but this PR loads all labels where they are used. I suspect there will need to be some optimisation though. 

I think all the labels should be available everywhere since they're not tags even though they're used by acts as taggable, the only issue is looking through some of the data there are some misspelled or duplicate labels that have been created and lost to time that may need clearing out in the db (they have no services assigned to most of them that I can tell). Though if there hadn't have been most_used that issue may not have occurred.
