### PR TITLE
If a label is removed from a user or service delete it from the db

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,8 @@ module Outpost
     config.action_mailer.notify_settings = {
       api_key: ENV["NOTIFY_API_KEY"]
     }
+
+    # remove unused tag objects after removing tagging
+    ActsAsTaggableOn.remove_unused_tags = true
   end
 end


### PR DESCRIPTION
So I went into full dev mode adding in a new view that lets you delete labels, then I found this and it makes so much more sense! https://github.com/mbleigh/acts-as-taggable-on#configuration

Currently there is no way for non-admins to delete labels assigned to users or services. 

This means when you edit a user or service and remove a label if its the last user or service that used that label that label sits in the database with nothing assigned to it unable to be deleted.

This config option changes this functionality so that if you remove a label from users and services it gets deleted from the database.