### PR TITLE
Bugfixes: Users marked for deletion bugs

### DIFF
--- a/app/assets/stylesheets/bucks-fis-design-library/_globals.scss
+++ b/app/assets/stylesheets/bucks-fis-design-library/_globals.scss
@@ -100,9 +100,6 @@ table{
         &:first-of-type a{
             font-weight: bold;
         }
-        &:last-of-type a{
-            margin-left: 10px;
-        }
     }
     tbody tr:nth-of-type(odd){
         background: $pale;

--- a/app/assets/stylesheets/bucks-fis-design-library/_help-tips.scss
+++ b/app/assets/stylesheets/bucks-fis-design-library/_help-tips.scss
@@ -45,6 +45,15 @@
                 font-size: 0.8rem;
             }
         }
+
+        &--warning{
+            border-color: $error;
+            color: $error;
+            opacity: 1;
+            &:after{
+                content: "!";
+            }
+        }
     }
 }
 

--- a/app/assets/stylesheets/bucks-fis-design-library/_layout.scss
+++ b/app/assets/stylesheets/bucks-fis-design-library/_layout.scss
@@ -120,6 +120,10 @@
             margin-right: 0px;
         }
     }
+
+    &--no-padding {
+        padding-bottom: 0;
+    }
 }
 
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -18,9 +18,7 @@
           <th>Organisation</th>
           <th>Joined</th>
           <th>Last seen</th>
-          <% if params[:deactivated] %>
-            <th class="visually-hidden">Actions</th>
-          <% end %>
+          <th class="visually-hidden">Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -63,13 +61,14 @@
               <% end %>
             </td>
             <td>
+              <div class="actions actions--no-padding">
               <% if u.marked_for_deletion? %>
-                <%= "Marked for deletion on #{u.marked_for_deletion.strftime("%d/%m/%Y")}" %>
-                <br>
+                 <button class="help-button help-button--warning help-button--small inline-button" type="button" data-tippy-content="<%= "User marked for deletion on #{u.marked_for_deletion.strftime("%d/%m/%Y")}" %>"><%= "User marked for deletion on #{u.marked_for_deletion.strftime("%d/%m/%Y")}" %></button>
               <% end %>
               <% if u.discarded? %>
                 <%= link_to "Reactivate", reactivate_admin_user_path(u), method: :put, data: {confirm: "Are you sure? This user will be able to sign in again."} %>
               <% end %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -62,11 +62,15 @@
                 Never logged in
               <% end %>
             </td>
-            <% if u.discarded? %>
-              <td>
+            <td>
+              <% if u.marked_for_deletion? %>
+                <%= "Marked for deletion on #{u.marked_for_deletion.strftime("%d/%m/%Y")}" %>
+                <br>
+              <% end %>
+              <% if u.discarded? %>
                 <%= link_to "Reactivate", admin_user_reactivate_path(u), method: "post", data: {confirm: "Are you sure? This user will be able to sign in again."} %>
-              </td>
-            <% end %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -68,7 +68,7 @@
                 <br>
               <% end %>
               <% if u.discarded? %>
-                <%= link_to "Reactivate", admin_user_reactivate_path(u), method: "post", data: {confirm: "Are you sure? This user will be able to sign in again."} %>
+                <%= link_to "Reactivate", reactivate_admin_user_path(u), method: :put, data: {confirm: "Are you sure? This user will be able to sign in again."} %>
               <% end %>
             </td>
           </tr>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -4,7 +4,7 @@
       <div class="notice notice--cross">
         <div class="notice__body">
           <p>This user is deactivated and can't sign in</p>
-          <%= link_to "Reactivate", admin_user_reactivate_path(@user), method: "post", class: "notice__action", data: {confirm: "Are you sure? This user will be able to sign in again."} %>
+          <%= link_to "Reactivate", reactivate_admin_user_path(@user), method: :put, class: "notice__action", data: {confirm: "Are you sure? This user will be able to sign in again."} %>
         </div>
       </div>
     <% elsif @user.admin? %>
@@ -68,7 +68,7 @@
     
       <%= render "shared/collapsible", name: "Password reset", id: "user-password-reset" do %>
           <p class="bottom-margin">Users must reset their own passwords, but you can send the instructions by email.</p>
-          <%= link_to "Trigger reset", admin_user_reset_path(@user), method: "post", class: "button button--secondary" %>
+          <%= link_to "Trigger reset", reset_admin_user_path(@user), method: "post", class: "button button--secondary" %>
       <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,8 +48,8 @@ Rails.application.routes.draw do
     resources :activity, only: [:index, :show]
     resources :custom_field_sections, except: [:edit]
     resources :users, except: [:edit] do
-      post "reset"
-      post "reactivate"
+      post :reset, on: :member
+      put :reactivate, on: :member
     end
   end
 

--- a/spec/features/managing_users_spec.rb
+++ b/spec/features/managing_users_spec.rb
@@ -15,10 +15,10 @@ feature 'Managing users', type: :feature do
     before do
       admin_user = FactoryBot.create :user, :superadmin
       login_as admin_user
+      visit admin_users_path
     end
 
     scenario 'I can see all users' do
-      visit admin_users_path
       expect(page).to have_content('All (3)')
       expect(page).to have_content('Active (2)')
       expect(page).to have_content('Deactivated (1)')
@@ -31,7 +31,6 @@ feature 'Managing users', type: :feature do
     end
 
     scenario 'I can filter by active users' do
-      visit admin_users_path
       click_link 'Active'
       expect(page).to have_content community_user.display_name
       expect(page).to_not have_content deactivated_user.display_name
@@ -42,7 +41,6 @@ feature 'Managing users', type: :feature do
     end
 
     scenario 'I can filter by deactivated users' do
-      visit admin_users_path
       click_link 'Deactivated'
       expect(page).to_not have_content community_user.display_name
       expect(page).to have_content deactivated_user.display_name
@@ -55,7 +53,6 @@ feature 'Managing users', type: :feature do
 
 
     scenario 'I can see details for a user' do
-      visit admin_users_path
       click_link community_user.display_name
       expect(page).to have_field('User can manage services', visible: false, checked: false)
       expect(page).to have_field('User can see Ofsted feed', visible: false, checked: false)
@@ -67,14 +64,34 @@ feature 'Managing users', type: :feature do
     before do
       admin_user = FactoryBot.create :user, :user_manager
       login_as admin_user
+      visit admin_users_path
     end
 
     scenario 'I can see details for a user' do
-      visit admin_users_path
       click_link community_user.display_name
       expect(page).to have_field('User can manage services', visible: false, checked: false)
       expect(page).to_not have_content 'User can see Ofsted feed'
       expect(page).to have_field('User can manage other users, taxonomies and custom fields', visible: false, checked: false)
+    end
+
+    scenario 'I can deactivate a user' do
+      expect(page).to have_content('Deactivated (1)')
+      click_link community_user.display_name
+      click_link 'Deactivate'
+      expect(page).to have_content 'That user has been deactivated'
+      expect(page).to have_content('Active (1)')
+      expect(page).to have_content('Deactivated (2)')
+    end
+
+    scenario 'I can mark a deactivated user for deletion' do
+      click_link 'Deactivated'
+      click_link deactivated_user.display_name
+      check 'user_marked_for_deletion'
+      click_button 'Update'
+      expect(page).to have_content 'User has been updated'
+      expect(page).to have_field('user_marked_for_deletion', checked: true)
+      click_link 'Back to users'
+      expect(page).to have_content 'Marked for deletion on'
     end
   end
 

--- a/spec/features/managing_users_spec.rb
+++ b/spec/features/managing_users_spec.rb
@@ -93,7 +93,21 @@ feature 'Managing users', type: :feature do
       click_link 'Back to users'
       expect(page).to have_content 'Marked for deletion on'
     end
-  end
 
+    context 'with a user marked for deletion' do
+      before do
+        deactivated_user.update(marked_for_deletion: Time.now)
+        visit admin_users_path
+      end
+
+      scenario 'I can reactivate the user and they will not be marked for deletion anymore' do
+        click_link deactivated_user.display_name
+        expect(page).to have_field('user_marked_for_deletion', checked: true)
+        click_link 'Reactivate'
+        expect(page).to have_content 'That user has been reactivated'
+        expect(deactivated_user.reload.marked_for_deletion).to be nil
+      end
+    end
+  end
 
 end

--- a/spec/features/managing_users_spec.rb
+++ b/spec/features/managing_users_spec.rb
@@ -91,7 +91,7 @@ feature 'Managing users', type: :feature do
       expect(page).to have_content 'User has been updated'
       expect(page).to have_field('user_marked_for_deletion', checked: true)
       click_link 'Back to users'
-      expect(page).to have_content 'Marked for deletion on'
+      expect(page).to have_content 'User marked for deletion on'
     end
 
     context 'with a user marked for deletion' do


### PR DESCRIPTION
This PR fixes a bug where you could reactivate a user that had been marked for deletion, and they would remain marked for deletion (but they wouldn't get deleted because when we delete users we check that they are not active).

While I was there I also cleaned up the routes a bit.

It also adds the date when someone was marked for deletion to the users index page. This is because there has been a lot of confusion around when users have been marked for deletion (we didn't show this anywhere in Outpost until now) and when their deletion is meant to be processed (30 days later).

I am open to suggestions of how to style this better! 😄 

<img width="1174" alt="Screenshot 2022-07-26 at 17 11 21" src="https://user-images.githubusercontent.com/11888656/181056957-2ce03587-00d5-4bc8-a916-2627f23c7aeb.png">
 