### PR TITLE
Adds styling and some css changes for users marked for deletion

### DIFF
--- a/app/assets/stylesheets/bucks-fis-design-library/_help-tips.scss
+++ b/app/assets/stylesheets/bucks-fis-design-library/_help-tips.scss
@@ -45,6 +45,15 @@
                 font-size: 0.8rem;
             }
         }
+
+        &--warning{
+            border-color: $error;
+            color: $error;
+            opacity: 1;
+            &:after{
+                content: "!";
+            }
+        }
     }
 }
 

--- a/app/assets/stylesheets/bucks-fis-design-library/_layout.scss
+++ b/app/assets/stylesheets/bucks-fis-design-library/_layout.scss
@@ -120,6 +120,10 @@
             margin-right: 0px;
         }
     }
+
+    &--no-padding {
+        padding-bottom: 0;
+    }
 }
 
 

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -18,9 +18,7 @@
           <th>Organisation</th>
           <th>Joined</th>
           <th>Last seen</th>
-          <% if params[:deactivated] %>
-            <th class="visually-hidden">Actions</th>
-          <% end %>
+          <th class="visually-hidden">Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -63,13 +61,14 @@
               <% end %>
             </td>
             <td>
+              <div class="actions actions--no-padding">
               <% if u.marked_for_deletion? %>
-                <%= "Marked for deletion on #{u.marked_for_deletion.strftime("%d/%m/%Y")}" %>
-                <br>
+                 <button class="help-button help-button--warning help-button--small inline-button" type="button" data-tippy-content="<%= "Marked for deletion on #{u.marked_for_deletion.strftime("%d/%m/%Y")}" %>">What does this mean?</button>
               <% end %>
               <% if u.discarded? %>
                 <%= link_to "Reactivate", reactivate_admin_user_path(u), method: :put, data: {confirm: "Are you sure? This user will be able to sign in again."} %>
               <% end %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -63,7 +63,7 @@
             <td>
               <div class="actions actions--no-padding">
               <% if u.marked_for_deletion? %>
-                 <button class="help-button help-button--warning help-button--small inline-button" type="button" data-tippy-content="<%= "Marked for deletion on #{u.marked_for_deletion.strftime("%d/%m/%Y")}" %>">What does this mean?</button>
+                 <button class="help-button help-button--warning help-button--small inline-button" type="button" data-tippy-content="<%= "User marked for deletion on #{u.marked_for_deletion.strftime("%d/%m/%Y")}" %>"><%= "User marked for deletion on #{u.marked_for_deletion.strftime("%d/%m/%Y")}" %></button>
               <% end %>
               <% if u.discarded? %>
                 <%= link_to "Reactivate", reactivate_admin_user_path(u), method: :put, data: {confirm: "Are you sure? This user will be able to sign in again."} %>

--- a/spec/features/managing_users_spec.rb
+++ b/spec/features/managing_users_spec.rb
@@ -91,7 +91,7 @@ feature 'Managing users', type: :feature do
       expect(page).to have_content 'User has been updated'
       expect(page).to have_field('user_marked_for_deletion', checked: true)
       click_link 'Back to users'
-      expect(page).to have_content 'Marked for deletion on'
+      expect(page).to have_content 'User marked for deletion on'
     end
 
     context 'with a user marked for deletion' do


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/649148/181604004-8ea29c7f-b345-402e-964a-63fe42def70c.png)

Extended the actions class to let it be used without padding! Added a tippy icon for users marked for deletion - its not ideal as it should really be more obvious what it means but then theres too much text in the table.

