### PR TITLE
Only trigger scout rebuild if hook is not empty

### DIFF
--- a/app/jobs/trigger_scout_rebuild_job.rb
+++ b/app/jobs/trigger_scout_rebuild_job.rb
@@ -2,7 +2,7 @@ class TriggerScoutRebuildJob < ApplicationJob
     queue_as :default
   
     def perform()
-        if ENV["SCOUT_BUILD_HOOK"]
+        if ENV["SCOUT_BUILD_HOOK"].present?
             HTTParty.post(ENV["SCOUT_BUILD_HOOK"])
         end
     end


### PR DESCRIPTION
If `.env` had 

```
SCOUT_BUILD_HOOK=
```

HTTParty would still post to the empty url causing errors in the logs. 