### PR TITLE
Hide create new custom field form on create section page if no sectio…

### DIFF
--- a/app/views/admin/custom_field_sections/_fields.html.erb
+++ b/app/views/admin/custom_field_sections/_fields.html.erb
@@ -32,6 +32,8 @@
     <% end %>
 </div>
 
+<% if params[:action] != 'new'  %>
+
 <h2 class="page-subheading">Fields</h2>
 <section class="repeater">
     <ul class="repeater__panels" aria-live="polite">
@@ -44,3 +46,5 @@
 
     <%= link_to_add_fields "Add a field", f, :custom_fields, "admin/custom_field_sections/repeatable-fields" %>
 </section>
+
+ <% end %>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/649148/182162354-3b0ea552-8cda-4647-8b34-75a0b421c677.png)


small one I noticed while working on the custom fields import script.

(nb custom fields require a section.)

In order to make a new custom field you either:
- `+ add section` and add section and fields in the same page (this doesn't work)
- go into existing section and add new there (this will work)

a field must have a section

custom fields section
```
accepts_nested_attributes_for :custom_fields, allow_destroy: true, reject_if: :all_blank
```

custom fields
```
belongs_to :custom_field_section
```

This is a small fix just to stop this bug presenting. 


In order to create a custom field now, you will need to create the section first, then go back and create the fields. I have logged a new ticket https://tpximpact.atlassian.net/browse/OUTPOST-141 for the UX work needed around this but for now at least the bug wont catch anyone out.




