### PR TITLE
Fix seed description to be string

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,7 +51,7 @@ end
         service = Service.create!({
             name: Faker::Company.name,
             organisation: org,
-            description: Faker::Lorem.paragraphs(number: 1).join(' '),
+            description: Faker::Lorem.paragraph,
             skip_mongo_callbacks: true
         })
         # byebug

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,7 +51,7 @@ end
         service = Service.create!({
             name: Faker::Company.name,
             organisation: org,
-            description: Faker::Lorem.paragraphs(number: 1),
+            description: Faker::Lorem.paragraphs(number: 1).join(' '),
             skip_mongo_callbacks: true
         })
         # byebug


### PR DESCRIPTION
This has been bugging me for ages!! Had to redo my db so.....

Service descriptions are now strings instead of `[ "blah" ]`

![image](https://user-images.githubusercontent.com/649148/184974230-3b0ab4b9-563c-4737-a823-4d03454195b4.png)
