### PR TITLE
Taxonomies no longer just one word but variable

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,7 +27,7 @@ end
 
 10.times do 
     taxon = Taxonomy.create!({
-        name: Faker::Lorem.word.capitalize
+        name: Faker::Lorem.words(number: rand(1...5)).join(' ').capitalize
     })
 end
 


### PR DESCRIPTION
Another small one but the lorum ipsum taxonomies all being one word just didn't sit right with me, have made it random between 1 and 5 now - a bit more natural 

I also kind of want to add subcategories too...

```ruby
# subcategories
taxonomy_ids = Taxonomy.last(10).map(&:id)
taxonomy_ids.each do | t |
    rand(0...10).times do 
        child_taxon = Taxonomy.create!({
            name: Faker::Lorem.words(number: rand(1...5)).join(' ').capitalize,
            parent_id: t
        })
    end
end
```