### PR TITLE
Add ids to regular schedule and cost option serializers

### DIFF
--- a/app/serializers/cost_option_serializer.rb
+++ b/app/serializers/cost_option_serializer.rb
@@ -1,5 +1,3 @@
 class CostOptionSerializer < ActiveModel::Serializer
-  attributes :option
-  attributes :amount
-  attributes :cost_type
+  attributes :id, :option, :amount, :cost_type
 end

--- a/app/serializers/regular_schedule_serializer.rb
+++ b/app/serializers/regular_schedule_serializer.rb
@@ -1,9 +1,7 @@
 include RegularScheduleHelper
 
 class RegularScheduleSerializer < ActiveModel::Serializer
-  attributes :weekday
-  attributes :opens_at
-  attributes :closes_at
+  attributes :id, :weekday, :opens_at, :closes_at
 
   def weekday
     weekdays.find{ |d| d[:value] === object.weekday }[:label]

--- a/spec/factories/cost_option.rb
+++ b/spec/factories/cost_option.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :cost_option do
     option { Faker::Lorem.sentence }
     amount { Faker::Number.number }
+
+    association :service
   end
 end

--- a/spec/serializers/cost_option_serializer_spec.rb
+++ b/spec/serializers/cost_option_serializer_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe CostOptionSerializer do
+  let(:cost_option) { FactoryBot.create :cost_option }
+  subject { described_class.new(cost_option) }
+
+  it "includes the expected attributes" do
+    expect(subject.attributes.keys).
+      to contain_exactly(
+        :id,
+        :option,
+        :amount,
+        :cost_type
+      )
+  end
+
+end

--- a/spec/serializers/regular_schedule_serializer_spec.rb
+++ b/spec/serializers/regular_schedule_serializer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RegularScheduleSerializer do
   it "includes the expected attributes" do
     expect(subject.attributes.keys).
       to contain_exactly(
+        :id,
         :weekday,
         :opens_at,
         :closes_at


### PR DESCRIPTION
This fixes an issue with Open Referral UK compliancy, which requires us to include an ID with the regular schedules and cost options.