### PR TITLE
Permit subtitle in parameters

### DIFF
--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -5,6 +5,7 @@ class Form::AdminSettings
   
     KEYS = %i(
       outpost_title
+      outpost_sub_title
       outpost_instance_name
       primary_color
       outpost_logo


### PR DESCRIPTION
Fixes a bug where you can't update the site subtitle.