### PR TITLE
Neatening up GCP credentials setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ yarn-debug.log*
 .DS_Store
 yarn.lock
 .vscode
+
+# Nothing to see here
+/config/secrets/*

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ It uses Google APIs for geocoding and map features, and Sendgrid to send emails.
 
 ## 💻 Running it locally
 
-
 For more information see [getting started](https://github.com/wearefuturegov/outpost/wiki/Getting-started)
 
 You need ruby and node.js installed, plus a PostgreSQL server running.
@@ -119,33 +118,38 @@ You can provide config with a `.env` file. Run `cp .env.example .env` to create 
 
 It needs the following extra environment variables to be set:
 
-| Variable                                        | Description                                                                                                               | Example                                                 | Required?                                         |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------- |
-| `GOOGLE_API_KEY`                                | with the geocoding API enabled, to geocode postcodes                                                                      |                                                         | Yes, for geocoding features                       |
-| `GOOGLE_CLIENT_KEY`                             | with the javascript and static maps APIs enabled, to add map views to admin screens                                       |                                                         | Yes, for map features                             |
-| `OFSTED_API_KEY` and `OFSTED_FEED_API_ENDPOINT` | to access the feed of Ofsted items                                                                                        |                                                         | Only if running Ofsted rake tasks                 |
-| `NOTIFY_API_KEY`                                | to send emails with [Notify](https://www.notifications.service.gov.uk)                                                    |                                                         | In production only                                |
-| `NOTIFY_TEMPLATE_ID`                            | ID of a notify template, as described [here](https://github.com/dxw/mail-notify#with-a-view)                              |                                                         | In production only                                |
-| `MAILER_HOST`                                   | where the app lives on the web, to correctly form urls in emails                                                          | https://example.com                                     | In production only                                |
-| `FEEDBACK_FORM_URL`                             | a form where users can submit feedback about the website                                                                  | https://example.com                                     | In production only                                |
-| `DATABASE_URL`                                  | the main PostgreSQL database                                                                                              | postgres://user:password<br/>@example.com:5432/database | Yes, if different from default, and in production |
-| `DB_URI`                                        | the MongoDB database for the public index                                                                                 | mongodb://user:password<br/>@example.com/database       | Yes, if using the API service                     |
-| `INITIAL_ADMIN_PASSWORD`                        | an initial admin password to log in with for local development                                                            |                                                         | Locally only                                      |
-| `SHOW_ENV_BANNER`                               | show a bright warning banner on non-production environments                                                               | staging                                                 | Only to warn about non-production environments    |
-| `GCP_PROJECT`                                     | Name of the google cloud project          | * | No                                                |
-| `GCP_BUCKET`                                     | Name of the google cloud bucket          | * | No                                                |
-| `GCP_PROJECT_ID`                                     | Name of the google cloud project id          | * | No                                                |
-| `GCP_PRIVATE_KEY_ID`                                     | Google cloud private key id          | * | No                                                |
-| `GCP_PRIVATE_KEY`                                     | Google cloud private key          | * | No                                                |
-| `GCP_CLIENT_EMAIL`                                     | Google cloud client email          | * | No                                                |
-| `GCP_CLIENT_ID`                                     | Google cloud client id          | * | No                                                |
-| `GCP_CLIENT_X509_CERT_URL`                                     |Google cloud x509 certificate          | * | No                                                |
-
-
+| Variable                                        | Description                                                                                  | Example                                                 | Required?                                         |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------- | ------------------------------------------------- |
+| `GOOGLE_API_KEY`                                | with the geocoding API enabled, to geocode postcodes                                         |                                                         | Yes, for geocoding features                       |
+| `GOOGLE_CLIENT_KEY`                             | with the javascript and static maps APIs enabled, to add map views to admin screens          |                                                         | Yes, for map features                             |
+| `OFSTED_API_KEY` and `OFSTED_FEED_API_ENDPOINT` | to access the feed of Ofsted items                                                           |                                                         | Only if running Ofsted rake tasks                 |
+| `NOTIFY_API_KEY`                                | to send emails with [Notify](https://www.notifications.service.gov.uk)                       |                                                         | In production only                                |
+| `NOTIFY_TEMPLATE_ID`                            | ID of a notify template, as described [here](https://github.com/dxw/mail-notify#with-a-view) |                                                         | In production only                                |
+| `MAILER_HOST`                                   | where the app lives on the web, to correctly form urls in emails                             | https://example.com                                     | In production only                                |
+| `FEEDBACK_FORM_URL`                             | a form where users can submit feedback about the website                                     | https://example.com                                     | In production only                                |
+| `DATABASE_URL`                                  | the main PostgreSQL database                                                                 | postgres://user:password<br/>@example.com:5432/database | Yes, if different from default, and in production |
+| `DB_URI`                                        | the MongoDB database for the public index                                                    | mongodb://user:password<br/>@example.com/database       | Yes, if using the API service                     |
+| `INITIAL_ADMIN_PASSWORD`                        | an initial admin password to log in with for local development                               |                                                         | Locally only                                      |
+| `SHOW_ENV_BANNER`                               | show a bright warning banner on non-production environments                                  | staging                                                 | Only to warn about non-production environments    |
+| `GCP_PROJECT`                                   | Name of the google cloud project                                                             | \*                                                      | Yes                                               |
+| `GCP_BUCKET`                                    | Name of the google cloud bucket                                                              | \*                                                      | Yes                                               |
+| `GCP_APPLICATION_CREDENTIALS`                   | JSON                                                                                         | \*                                                      | Yes                                               |
 
 ## 💿 Data import
 
 See documentation on [data import](lib/tasks/data_import/README.md).
+
+## 🌥 Google Cloud Active Storage
+
+Setting up google cloud active storage.
+
+When working locally, you can drop your `keyfile.json` into `config/secrets/gcp.json`
+
+To deploy your credentials use
+
+```sh
+heroku config:set GCP_APPLICATION_CREDENTIALS="$(< config/secrets/gcp.json)" -a heroku-app-name
+```
 
 ## 🔐 OAuth provider
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :public_google
+  config.active_storage.service = :public_google_dev
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :public_google
+  config.active_storage.service = :public_google_prod
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,23 +6,17 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-public_google:
+public_google_dev:
   service: GCS
   project: <%= ENV['GCP_PROJECT'] %>
-  # credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-  credentials:
-    type: "service_account"
-    project_id: <%= ENV['GCP_PROJECT_ID'] %>
-    private_key_id: <%= ENV['GCP_PRIVATE_KEY_ID'].nil? ? '' : ENV['GCP_PRIVATE_KEY_ID'] %>
-    private_key: <%= ENV['GCP_PRIVATE_KEY'].nil? ? '' : ENV['GCP_PRIVATE_KEY'] %>
-    client_email: <%= ENV['GCP_CLIENT_EMAIL'] %>
-    client_id: <%= ENV['GCP_CLIENT_ID'] %>
-    auth_uri: "https://accounts.google.com/o/oauth2/auth"
-    token_uri: "https://oauth2.googleapis.com/token"
-    auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs"
-    client_x509_cert_url: <%= ENV['GCP_CLIENT_X509_CERT_URL'] %>
+  credentials: <%= Rails.root.join("config/secrets/tpx-outpost-dev.json") %>
   bucket: <%= ENV['GCP_BUCKET'] %>
 
+public_google_prod:
+  service: GCS
+  project: <%= ENV['GCP_PROJECT'] %>
+  credentials: <%= ENV['GCP_APPLICATION_CREDENTIALS'].as_json %>
+  bucket: <%= ENV['GCP_BUCKET'] %>
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
This PR makes the setup for GCP buckets much neater and less likely to cause errors on your local environment if you don't have everything setup yet.  (I was getting fed up of that header error.) Should help fix the error on https://github.com/wearefuturegov/outpost/pull/256 

one step closer to secrets management! 

I have tested locally and on tpx demo staging https://tpx-outpost-demo-staging.herokuapp.com/

## Deployment notes 
### **To use GCP locally on development**

* download the `keyfile.json` for the bucket you want to use (1password) and drop it into your `/config/secrets/` folder (rename it `gcp.json`)
* Set your local vars - you wont need any other `GCP_*` ones anymore
```
GCP_PROJECT=bucket_name
GCP_BUCKET=project_name
```
* when running locally it will use this bucket for storage


### **To use GCP on heroku** 

* As above download the `keyfile.json` for the bucket you want to use (1password)
* update the lines below to match your json file - along with the bucket and project names
```sh
heroku config:set -a heroku-app-name \
GCP_BUCKET=bucket_name \
GCP_PROJECT=project_name \ 
GCP_APPLICATION_CREDENTIALS="$(< config/secrets/correct-keyfile-for-env.json)"
```




