### PR TITLE
Restrict access to site settings page to superadmins

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,23 +1,27 @@
 class Admin::SettingsController < Admin::BaseController
+  before_action :require_superadmin!
 
-      def edit 
-        @admin_settings = Form::AdminSettings.new
-      end
+  def edit
+    @admin_settings = Form::AdminSettings.new
+  end
 
-      def update
+  def update
+    @admin_settings = Form::AdminSettings.new(setting_params)
 
-        @admin_settings = Form::AdminSettings.new(setting_params)
+    if @admin_settings.save
+      redirect_to edit_admin_settings_path(@admin_settings), notice: "Settings have been saved."
+    else
+      render :edit
+    end
+  end
 
-        if @admin_settings.save
-          redirect_to edit_admin_settings_path(@admin_settings), notice: "Settings have been saved."
-        else
-          render :edit
-        end
+  private
 
-      end
-  
-      private
-        def setting_params
-          params.require(:form_admin_settings).permit(*Form::AdminSettings::KEYS)
-        end
+  def setting_params
+    params.require(:form_admin_settings).permit(*Form::AdminSettings::KEYS)
+  end
+
+  def require_superadmin!
+    redirect_to root_path unless current_user.superadmin
+  end
 end

--- a/db/migrate/20221005141547_add_superadmin_to_users.rb
+++ b/db/migrate/20221005141547_add_superadmin_to_users.rb
@@ -1,0 +1,5 @@
+class AddSuperadminToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :superadmin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_23_112854) do
+ActiveRecord::Schema.define(version: 2022_10_05_141547) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_trgm"
@@ -438,6 +438,7 @@ ActiveRecord::Schema.define(version: 2022_06_23_112854) do
     t.string "phone"
     t.datetime "marked_for_deletion"
     t.boolean "admin_manage_ofsted_access", default: false, null: false
+    t.boolean "superadmin", default: false, null: false
     t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["organisation_id"], name: "index_users_on_organisation_id"

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -25,7 +25,15 @@ FactoryBot.define do
       admin_ofsted { true }
     end
 
+    trait :full_admin do
+      admin { true }
+      admin_users { true }
+      admin_ofsted { true }
+      admin_manage_ofsted_access { true }
+    end
+
     trait :superadmin do
+      superadmin { true }
       admin { true }
       admin_users { true }
       admin_ofsted { true }

--- a/spec/features/editing_site_settings_spec.rb
+++ b/spec/features/editing_site_settings_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+feature 'Editing site settings' do
+
+  context 'as a regular admin' do
+    let(:admin) { FactoryBot.create :user, :services_admin }
+
+    before { login_as admin }
+
+    it 'cannot view or update site settings' do
+      visit edit_admin_settings_path
+      expect(page).to_not have_current_path edit_admin_settings_path
+      expect(page).to_not have_content 'Outpost title'
+    end
+  end
+
+  context 'as a super admin' do
+    let(:admin) { FactoryBot.create :user, :superadmin }
+
+    before { login_as admin }
+
+    it 'can view and edit site settings' do
+      visit edit_admin_settings_path
+      expect(page).to have_current_path edit_admin_settings_path
+      expect(page).to have_content 'Outpost title'
+    end
+  end
+end

--- a/spec/features/editing_site_settings_spec.rb
+++ b/spec/features/editing_site_settings_spec.rb
@@ -19,10 +19,20 @@ feature 'Editing site settings' do
 
     before { login_as admin }
 
-    it 'can view and edit site settings' do
+    it 'can view site settings' do
       visit edit_admin_settings_path
       expect(page).to have_current_path edit_admin_settings_path
       expect(page).to have_content 'Outpost title'
+    end
+
+    it 'can edit site settings' do
+      site_name = 'My service directory'
+      visit edit_admin_settings_path
+      fill_in :form_admin_settings_outpost_title, with: site_name
+      click_button 'Save'
+      expect(page).to have_content 'Settings have been saved'
+      visit root_path
+      expect(page).to have_content site_name
     end
   end
 end

--- a/spec/features/managing_taxonomies_spec.rb
+++ b/spec/features/managing_taxonomies_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Managing taxonomies', type: :feature do
   before do
-    admin_user = FactoryBot.create :user, :superadmin
+    admin_user = FactoryBot.create :user, :full_admin
     login_as admin_user
     visit admin_taxonomies_path
   end

--- a/spec/features/managing_users_spec.rb
+++ b/spec/features/managing_users_spec.rb
@@ -11,9 +11,9 @@ feature 'Managing users', type: :feature do
     expect(page).to_not have_content 'Manage Ofsted'
   end
 
-  context 'as a superadmin' do
+  context 'as a full admin' do
     before do
-      admin_user = FactoryBot.create :user, :superadmin
+      admin_user = FactoryBot.create :user, :full_admin
       login_as admin_user
       visit admin_users_path
     end


### PR DESCRIPTION
This adds a new flag on users for `superadmins` and restricts access to the site settings page to superadmins only.