### PR TITLE
Fix organisation name requirement bug

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,8 +2,8 @@ class Organisation < ApplicationRecord
   has_many :services
   has_many :users
 
-  validates :name, presence: true, uniqueness: true
-  validates :name, length: { minimum: 2, maximum: 100 }, if: -> { name.present? }
+  # validates :name, presence: true, 
+  validates :name, length: { minimum: 2, maximum: 100 }, uniqueness: true, if: -> { name.present? }
 
   attr_accessor :skip_mongo_callbacks
   after_commit :update_index, if: -> { skip_mongo_callbacks != true }

--- a/app/views/organisations/_form.html.erb
+++ b/app/views/organisations/_form.html.erb
@@ -3,9 +3,9 @@
     <%= render "shared/errors", model: @organisation %>
 
     <div class="field-section field-section--two-cols">
-        <div class="field field--required">
+        <div class="field">
             <%= f.label :name, "Organisation name", class: "field__label" %>
-            <%= f.text_field :name, required: true, class: "field__input one-half" %>
+            <%= f.text_field :name, class: "field__input one-half" %>
         </div>
     </div>
 

--- a/spec/models/organisation_spec.rb
+++ b/spec/models/organisation_spec.rb
@@ -1,6 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Organisation, type: :model do
-  it { should validate_presence_of :name }
-  it { should validate_uniqueness_of :name }
+  it { should allow_value(nil).for(:name) }
+  it { should allow_value('Some Name').for(:name) }
+  it { should validate_uniqueness_of(:name) }
+  it { should validate_length_of(:name).is_at_least(2).is_at_most(100).allow_nil }
+
+  #  This tests the behavior that multiple organisations can have a nil name.
+  it 'allows nil names' do
+    first = Organisation.create!(name: nil)
+    second = Organisation.new(name: nil)
+
+    expect(second).to be_valid
+  end
+
+
+  it 'Does not allow duplicate names' do
+    first = Organisation.create!(name: "Organisation 1")
+    second = Organisation.new(name: "Organisation 1")
+
+    expect(second).to be_invalid
+  end
 end


### PR DESCRIPTION
Organisations can have no name, since they might not always be relevant. This is a fix to revert back to the previous behaviour of Outpost