### PR TITLE
Top 196 display second level taxonomies in scout

### DIFF
--- a/.docker/services/mongo/mongo.yml
+++ b/.docker/services/mongo/mongo.yml
@@ -2,15 +2,16 @@ version: "3.7"
 services:
   mongo:
     image: mongo:6
-    container_name: mongo
     ports:
       - 27018:27017
     volumes:
       - mongo-volume:/data/db
       - ./setup-mongodb.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
     environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-outpost}
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-admin}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-password}
+      MONGO_INITDB_USERNAME: ${MONGO_INITDB_USERNAME:-outpost}
+      MONGO_INITDB_PASSWORD: ${MONGO_INITDB_PASSWORD:-password}
       MONGO_INITDB_DATABASE: ${MONGO_INITDB_DATABASE:-outpost_api_development}
     networks:
       - internal_network

--- a/.docker/services/mongo/setup-mongodb.js
+++ b/.docker/services/mongo/setup-mongodb.js
@@ -3,8 +3,8 @@ db = db.getSiblingDB(
 );
 
 db.createUser({
-  user: process.env.MONGO_INITDB_ROOT_USERNAME || "outpost",
-  pwd: process.env.MONGO_INITDB_ROOT_PASSWORD || "password",
+  user: process.env.MONGO_INITDB_USERNAME || "outpost",
+  pwd: process.env.MONGO_INITDB_PASSWORD || "password",
   roles: [
     {
       role: "readWrite",

--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -6,7 +6,7 @@ class API::V1::TaxonomiesController < ApplicationController
         directory_labels = params[:directory]
         directories = Directory.where(label: directory_labels)
         if directory_labels.present? && directories.present?
-            render json: json_tree(Taxonomy.filter_by_directory(directory_labels).hash_tree).to_json
+            render json: json_tree(Taxonomy.filter_by_directory(directories.pluck('name')).hash_tree).to_json
         else
             render json: json_tree(Taxonomy.hash_tree).to_json
         end

--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -1,10 +1,12 @@
 class API::V1::TaxonomiesController < ApplicationController
     skip_before_action :authenticate_user!
 
+    # ?directory[]=bfis&directory[]=bod
     def index
-        directory = Directory.find_by(label: params[:directory])
-        if params[:directory].present? && directory
-            render json: json_tree(Taxonomy.filter_by_directory(directory.name).hash_tree).to_json
+        directory_labels = params[:directory]
+        directories = Directory.where(label: directory_labels)
+        if directory_labels.present? && directories.present?
+            render json: json_tree(Taxonomy.filter_by_directory(directory_labels).hash_tree).to_json
         else
             render json: json_tree(Taxonomy.hash_tree).to_json
         end

--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -1,9 +1,9 @@
 class API::V1::TaxonomiesController < ApplicationController
     skip_before_action :authenticate_user!
 
-    # ?directory[]=bfis&directory[]=bod
+    # ?directories[]=bfis&directories[]=bod
     def index
-        directory_labels = params[:directory]
+        directory_labels = params[:directories]
         directories = Directory.where(label: directory_labels)
         if directory_labels.present? && directories.present?
             render json: json_tree(Taxonomy.filter_by_directory(directories.pluck('name')).hash_tree).to_json

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -26,6 +26,15 @@ class Taxonomy < ApplicationRecord
     end
 
     def self.options_for_select
-      order("LOWER(name)").map { |e| [e.name, e.id] }.unshift(["All taxonomies", ""])
+        # order("LOWER(name)").map { |e| [e.name, e.id] }.unshift(["All taxonomies", ""])
+        Taxonomy.arranged_as_flat_array.map { |name, id| [name.html_safe, id] }.unshift(["All taxonomies", ""])
     end
+
+    def self.arranged_as_flat_array(taxonomies = nil, level = 0)
+        taxonomies ||= Taxonomy.hash_tree
+      
+        taxonomies.map do |taxonomy, sub_taxonomies|
+          [["#{"&nbsp;" * level}#{taxonomy.name}", taxonomy.id], *arranged_as_flat_array(sub_taxonomies, level + 1)]
+        end.flatten(1)
+      end
 end

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -21,7 +21,7 @@ class IndexedServicesSerializer < ActiveModel::Serializer
     :created_at,
     :status
 
-  has_many :target_directories do 
+  has_many :directories do 
     object.directories.map do |directory|
       { name: directory.name, label: directory.label }
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,11 +61,27 @@ if seed_dummy_data
         location.save
     end
 
-    10.times do 
+
+    # create nested taxonomies - chance of subcategories being generated is different at each level
+    def create_taxonomy(level = 0, parent_id = nil)
+        return if level >= 4
+      
         taxon = Taxonomy.create!({
-            name: Faker::Lorem.words(number: rand(1...5)).join(' ').capitalize
+          name: Faker::Lorem.words(number: rand(2...5)).join(' ').capitalize,
+          parent_id: parent_id
         })
+      
+        case level
+        when 0
+          rand(2..10).times { create_taxonomy(level + 1, taxon.id) } if rand < 0.50
+        when 1
+          rand(3..15).times { create_taxonomy(level + 1, taxon.id) } if rand < 0.2
+        when 2
+          rand(1..3).times { create_taxonomy(level + 1, taxon.id) } if rand < 0.15
+        end
     end
+      
+    5.times { create_taxonomy }
 
     10.times do
         org = Organisation.create!({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       # RAILS_ENV: production
       OFSTED_FEED_API_ENDPOINT: ${OFSTED_FEED_API_ENDPOINT:-https://test-ofsted-feed.stub} # this is not a real url, we just need an env variable set for the stub to work in tests
       SHOW_ENV_BANNER: ${SHOW_ENV_BANNER:-outpost docker development}
-      DB_URI: ${DB_URI:-mongodb://mongo:27017/outpost_api_development}
+      DB_URI: mongodb://${MONGO_INITDB_USERNAME:-outpost}:${MONGO_INITDB_PASSWORD:-password}@mongo/${MONGO_INITDB_DATABASE:-outpost_api_development}
       DATABASE_URL: ${DATABASE_URL:-postgresql://outpost:password@postgres:5432/outpost?}
     networks:
       - external_network

--- a/spec/requests/api/get_taxonomies_spec.rb
+++ b/spec/requests/api/get_taxonomies_spec.rb
@@ -35,13 +35,13 @@ describe 'GET taxonomies endpoint', type: :request do
       end
 
       it 'can filter by directory' do
-        get "/api/v1/taxonomies?directory=#{directory_a.label}"
+        get "/api/v1/taxonomies?directory[]=#{directory_a.label}"
         response_body = JSON.parse(response.body)
 
         root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
         expect(root_taxonomy_ids).to match_array([root_taxonomy.id])
 
-        get "/api/v1/taxonomies?directory=#{directory_b.label}"
+        get "/api/v1/taxonomies?directory[]=#{directory_b.label}"
         response_body = JSON.parse(response.body)
 
         root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
@@ -51,7 +51,7 @@ describe 'GET taxonomies endpoint', type: :request do
       context 'filtering by an empty directory' do
         let!(:directory_c) { FactoryBot.create(:directory, name: "Directory C", label: "c") }
         it 'returns no results' do
-          get "/api/v1/taxonomies?directory=#{directory_c.label}"
+          get "/api/v1/taxonomies?directory[]=#{directory_c.label}"
           response_body = JSON.parse(response.body)
           expect(response_body).to match_array([])
         end
@@ -59,7 +59,7 @@ describe 'GET taxonomies endpoint', type: :request do
 
       context 'filtering by a directory that does not exist' do
         it 'returns all results' do
-          get "/api/v1/taxonomies?directory=not-a-real-directory"
+          get "/api/v1/taxonomies?directory[]=not-a-real-directory"
           response_body = JSON.parse(response.body)
 
           root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}

--- a/spec/requests/api/get_taxonomies_spec.rb
+++ b/spec/requests/api/get_taxonomies_spec.rb
@@ -35,13 +35,13 @@ describe 'GET taxonomies endpoint', type: :request do
       end
 
       it 'can filter by directory' do
-        get "/api/v1/taxonomies?directory[]=#{directory_a.label}"
+        get "/api/v1/taxonomies?directories[]=#{directory_a.label}"
         response_body = JSON.parse(response.body)
 
         root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
         expect(root_taxonomy_ids).to match_array([root_taxonomy.id])
 
-        get "/api/v1/taxonomies?directory[]=#{directory_b.label}"
+        get "/api/v1/taxonomies?directories[]=#{directory_b.label}"
         response_body = JSON.parse(response.body)
 
         root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
@@ -51,7 +51,7 @@ describe 'GET taxonomies endpoint', type: :request do
       context 'filtering by an empty directory' do
         let!(:directory_c) { FactoryBot.create(:directory, name: "Directory C", label: "c") }
         it 'returns no results' do
-          get "/api/v1/taxonomies?directory[]=#{directory_c.label}"
+          get "/api/v1/taxonomies?directories[]=#{directory_c.label}"
           response_body = JSON.parse(response.body)
           expect(response_body).to match_array([])
         end
@@ -59,7 +59,7 @@ describe 'GET taxonomies endpoint', type: :request do
 
       context 'filtering by a directory that does not exist' do
         it 'returns all results' do
-          get "/api/v1/taxonomies?directory[]=not-a-real-directory"
+          get "/api/v1/taxonomies?directories[]=not-a-real-directory"
           response_body = JSON.parse(response.body)
 
           root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}


### PR DESCRIPTION
This PR:

- Adds in 'nested' view for taxonomies in the services filter view **only**
![image](https://github.com/wearefuturegov/outpost/assets/649148/9f367339-1cc7-4673-8791-f20b501ddb59)
- Updates the seed script to generate subcategories
- Updates the docker env mongo setup to ensure that the outpost user has the right permissions to access/update/remove_all data
- `/api/v1/taxonomies` can now fetch one or more results `http://localhost:3000/api/v1/taxonomies?directories[]=bfis` `http://localhost:3000/api/v1/taxonomies?directories[]=bod` `http://localhost:3000/api/v1/taxonomies?directories[]=bfis&directories[]=bod`
- indexed services are passed over with `directories` instead of `target_directories` (for consistency)