### PR TITLE
Staging PR

### DIFF
--- a/.docker/services/mongo/mongo.yml
+++ b/.docker/services/mongo/mongo.yml
@@ -2,15 +2,16 @@ version: "3.7"
 services:
   mongo:
     image: mongo:6
-    container_name: mongo
     ports:
       - 27018:27017
     volumes:
       - mongo-volume:/data/db
       - ./setup-mongodb.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
     environment:
-      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-outpost}
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME:-admin}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD:-password}
+      MONGO_INITDB_USERNAME: ${MONGO_INITDB_USERNAME:-outpost}
+      MONGO_INITDB_PASSWORD: ${MONGO_INITDB_PASSWORD:-password}
       MONGO_INITDB_DATABASE: ${MONGO_INITDB_DATABASE:-outpost_api_development}
     networks:
       - internal_network

--- a/.docker/services/mongo/setup-mongodb.js
+++ b/.docker/services/mongo/setup-mongodb.js
@@ -3,8 +3,8 @@ db = db.getSiblingDB(
 );
 
 db.createUser({
-  user: process.env.MONGO_INITDB_ROOT_USERNAME || "outpost",
-  pwd: process.env.MONGO_INITDB_ROOT_PASSWORD || "password",
+  user: process.env.MONGO_INITDB_USERNAME || "outpost",
+  pwd: process.env.MONGO_INITDB_PASSWORD || "password",
   roles: [
     {
       role: "readWrite",

--- a/.docker/services/postgres/postgres.yml
+++ b/.docker/services/postgres/postgres.yml
@@ -2,7 +2,6 @@ version: "3.7"
 services:
   postgres:
     image: postgres:13.7-alpine
-    container_name: postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-outpost}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}

--- a/app/assets/stylesheets/outpost-design-library/_taxonomy-tree.scss
+++ b/app/assets/stylesheets/outpost-design-library/_taxonomy-tree.scss
@@ -1,10 +1,9 @@
-
-
-.taxonomy-tree{
-    list-style: none;
+.taxonomy-tree {
+  list-style: none;
+  margin: 20px 0px;
 }
 
-
-.panel > .taxonomy-tree{
-    padding-left: 0px;
+.panel > .taxonomy-tree {
+  padding-left: 0px;
+  margin-left: 0px;
 }

--- a/app/controllers/admin/custom_field_sections_controller.rb
+++ b/app/controllers/admin/custom_field_sections_controller.rb
@@ -3,7 +3,7 @@ class Admin::CustomFieldSectionsController < Admin::BaseController
   before_action :set_section, only: [:show, :update, :destroy]
 
   def index
-    @sections = CustomFieldSection.includes(:custom_fields).all
+    @sections = CustomFieldSection.all
   end
 
   def new

--- a/app/controllers/admin/services_controller.rb
+++ b/app/controllers/admin/services_controller.rb
@@ -9,7 +9,6 @@ class Admin::ServicesController < Admin::BaseController
       params[:filterrific],
       select_options: {
         sorted_by: Service.options_for_sorted_by,
-        in_taxonomy: Taxonomy.options_for_select,
         with_status: Service.options_for_status,
         tagged_with: Service.options_for_labels
       },

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,6 +1,10 @@
 class Admin::SettingsController < Admin::BaseController
   before_action :require_superadmin!
 
+  def show
+    # redirect_to edit_admin_settings_path()
+  end
+
   def edit
     @admin_settings = Form::AdminSettings.new
   end

--- a/app/controllers/admin/taxonomies_controller.rb
+++ b/app/controllers/admin/taxonomies_controller.rb
@@ -3,7 +3,6 @@ class Admin::TaxonomiesController < Admin::BaseController
   before_action :count_taxonomies, only: [:index]
   before_action :set_taxonomies, only: [:index, :create]
   before_action :set_taxonomy, only: [:show, :update, :destroy]
-  before_action :set_possible_parents, only: [:show, :update, :index, :create]
 
   def index
     @taxonomy = Taxonomy.new
@@ -50,11 +49,6 @@ class Admin::TaxonomiesController < Admin::BaseController
 
   def set_taxonomy
     @taxonomy = Taxonomy.find(params[:id])
-  end
-
-  def set_possible_parents
-    @possible_parents = Taxonomy.all
-    @possible_parents = @possible_parents.where.not(id: params[:id]) if params[:id]
   end
 
   def taxonomy_params

--- a/app/controllers/admin/tools/bulk_add_taxonomies_controller.rb
+++ b/app/controllers/admin/tools/bulk_add_taxonomies_controller.rb
@@ -1,0 +1,145 @@
+# This tool is for superadmins only right now
+# it is only very simply optimised for large number of services, 
+# if you run into errors you should be able to just re-run the command with it only updating ones where data will be changing
+class Admin::Tools::BulkAddTaxonomiesController < Admin::BaseController
+
+  def show
+    @errors = flash.now[:errors] || []
+  end
+
+  def update
+    services_taxonomy_id = params[:taxonomy]
+    taxonomy_ids = setup_taxonomy_ids(params[:taxonomy_ids], services_taxonomy_id)
+
+    if services_taxonomy_id.present? && taxonomy_ids.length > 0
+      
+      updated_services = 0
+      skipped_services = 0
+      errors_count = 0
+      errors = []
+
+      Service.joins(:service_taxonomies).where(service_taxonomies: { taxonomy_id: services_taxonomy_id }).includes(:taxonomies, :versions, :organisation, :service_at_locations, :locations, :directories_services, :directories, :taggings).distinct.find_each(batch_size: 10) do |service|
+        
+        service_updated = false
+        service_taxonomy_ids = service.taxonomies.map(&:id)
+
+        # budget optimisation - skip if the service already has the taxonomies we're wanting to add to it
+        if (taxonomy_ids - service_taxonomy_ids).empty?
+          skipped_services += 1
+          next
+        end
+
+        # force paper trail version to be saved
+        service.updated_at = Time.now
+
+        # dont notify watchers
+        service.skip_notify_watchers = true
+
+        # we found the parents above to save some time
+        service.skip_add_parent_taxonomies = true
+
+        # we don't want to update the mongo index we can do that later
+        service.skip_mongo_callbacks = true
+
+        # skip things that do extra database lookups
+        service.skip_cost_option_validation = true
+
+      
+        begin
+          service_updated = ActiveRecord::Base.transaction do
+            
+            update_service = PaperTrail.request(enabled: false) do
+              service.update!(taxonomy_ids: (service_taxonomy_ids | taxonomy_ids))
+            end
+
+            if update_service
+
+              # create a manual papertrail version (if update is successful)
+              # the .to_json method in service does a lot of queries and we know we're only updating the taxonomies and updated_at date here
+              last_version = service.versions.last.object
+              current_changes = service.as_json(only: [:taxonomies, :updated_at], include: { taxonomies: { methods: :slug } })
+              new_object = last_version.merge(current_changes)
+              
+              version = PaperTrail::Version.create(
+                item_type: 'Service', 
+                item_id: service.id, 
+                event: 'update', 
+                whodunnit: nil, 
+                object: new_object,
+                object_changes: service.saved_changes
+              )
+              version.persisted? if version
+            else
+              false
+            end
+
+          end
+        rescue ActiveRecord::RecordInvalid => e
+          puts "Caught RecordInvalid exception: #{e.message}"
+          errors << { id: service.id, name: service.name, error: "RecordInvalid", messages: [e.message] }
+          errors_count += 1
+        rescue ActiveRecord::RecordNotFound => e
+          puts "Caught RecordNotFound exception: #{e.message}"
+          errors << { id: service.id, name: service.name, error: "RecordNotFound", messages: [e.message] }
+          errors_count += 1
+        end
+
+
+        if service_updated
+          updated_services += 1
+        else
+          if !errors.map { |e| e[:id] }.include?(service.id)
+            errors << { id: service.id, name: service.name, error: 'Transaction failed', messages: ['Update transaction failed, please view logs for more information']}
+            errors_count += 1
+          end
+        end
+
+
+      end
+
+      # sort by id in case of dupes
+      errors.sort_by! { |error| error[:id] }
+
+
+      puts errors.inspect
+      if errors.any?        
+        flash.now[:alert] = "#{updated_services} services have been updated. #{skipped_services} services were skipped. There were #{errors_count} errors."
+        @errors = errors
+        render :show
+      else
+        redirect_to admin_settings_tools_bulk_add_taxonomies_path, notice: "#{updated_services} services have been updated. #{skipped_services} services were skipped."
+      end
+
+    else
+      redirect_to admin_settings_tools_bulk_add_taxonomies_path, alert: "Please select at least one taxonomy to add."
+    end
+  end
+
+  private
+
+
+  def setup_taxonomy_ids(tax_ids, services_taxonomy_id)
+    # remove empty values
+    taxonomy_ids = tax_ids.reject { |c| c.empty? }
+
+    # remove current taxonomy from list 
+    taxonomy_ids = taxonomy_ids.reject { |c| c == services_taxonomy_id }
+
+    # ensure the taxonomy id's are integers
+    taxonomy_ids = taxonomy_ids.map(&:to_i)
+
+    # to speed things up we fetch the parents of the selected taxonomies here
+    # that way we can safely skip the add_parent_taxonomies callback 
+    parent_taxonomy_ids = []
+    taxonomy_ids.each do |taxonomy_id|
+      parents = Taxonomy.find(taxonomy_id).ancestors.pluck(:id)
+      parent_taxonomy_ids.concat(parents)
+    end
+
+    taxonomy_ids = (taxonomy_ids + parent_taxonomy_ids).uniq
+  end
+
+
+
+
+end

--- a/app/controllers/api/v1/me_controller.rb
+++ b/app/controllers/api/v1/me_controller.rb
@@ -8,7 +8,7 @@ class API::V1::MeController < ApplicationController
                 organisation: { 
                     only: [:id, :name], 
                     include: [
-                        services: {only: [:id, :name]}
+                        services: {only: [:id, :name, :postcode]}
                     ]
                 }
             ])

--- a/app/controllers/api/v1/me_controller.rb
+++ b/app/controllers/api/v1/me_controller.rb
@@ -8,7 +8,7 @@ class API::V1::MeController < ApplicationController
                 organisation: { 
                     only: [:id, :name], 
                     include: [
-                        services: {only: [:id, :name, :postcode]}
+                        services: {only: [:id, :name]}
                     ]
                 }
             ])

--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -6,7 +6,7 @@ class API::V1::TaxonomiesController < ApplicationController
         directory_labels = params[:directory]
         directories = Directory.where(label: directory_labels)
         if directory_labels.present? && directories.present?
-            render json: json_tree(Taxonomy.filter_by_directory(directory_labels).hash_tree).to_json
+            render json: json_tree(Taxonomy.filter_by_directory(directories.pluck('name')).hash_tree).to_json
         else
             render json: json_tree(Taxonomy.hash_tree).to_json
         end

--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -1,10 +1,12 @@
 class API::V1::TaxonomiesController < ApplicationController
     skip_before_action :authenticate_user!
 
+    # ?directory[]=bfis&directory[]=bod
     def index
-        directory = Directory.find_by(label: params[:directory])
-        if params[:directory].present? && directory
-            render json: json_tree(Taxonomy.filter_by_directory(directory.name).hash_tree).to_json
+        directory_labels = params[:directory]
+        directories = Directory.where(label: directory_labels)
+        if directory_labels.present? && directories.present?
+            render json: json_tree(Taxonomy.filter_by_directory(directory_labels).hash_tree).to_json
         else
             render json: json_tree(Taxonomy.hash_tree).to_json
         end

--- a/app/controllers/api/v1/taxonomies_controller.rb
+++ b/app/controllers/api/v1/taxonomies_controller.rb
@@ -1,9 +1,9 @@
 class API::V1::TaxonomiesController < ApplicationController
     skip_before_action :authenticate_user!
 
-    # ?directory[]=bfis&directory[]=bod
+    # ?directories[]=bfis&directories[]=bod
     def index
-        directory_labels = params[:directory]
+        directory_labels = params[:directories]
         directories = Directory.where(label: directory_labels)
         if directory_labels.present? && directories.present?
             render json: json_tree(Taxonomy.filter_by_directory(directories.pluck('name')).hash_tree).to_json

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -61,8 +61,9 @@ class ServicesController < ApplicationController
 
     def set_service
         @service = current_user.organisation.services.find(params[:id] || params[:service_id])
-        @custom_field_sections = CustomFieldSection.includes(:custom_fields).visible_to(current_user)
+        @custom_field_sections = CustomFieldSection.visible_to(current_user).where('custom_fields_count > 0')
     end
+
 
     def service_params
         result_params = params.require(:service).permit(

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -109,4 +109,18 @@ module ApplicationHelper
         return true if params[:mobile] == "1"
         request.user_agent =~ /Mobile|webOS/
     end  
+
+    def get_header_image
+        if Rails.configuration.active_storage.service == :public_google
+            logo = FileUpload.find_by(var: 'outpost_logo')
+            if logo.present?
+                logo_url = url_for(logo.file)
+                image_tag(logo_url, alt: Setting.outpost_title, class: "site-header__logo") 
+            else 
+                image_tag("logo-outpost.svg", alt: "Outpost", class: "site-header__logo") 
+            end
+        else 
+            image_tag("logo-outpost.svg", alt: "Outpost", class: "site-header__logo") 
+        end
+    end
 end

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -1,7 +1,7 @@
 module TaskListHelper
 
-    def task_list_sections
-        [
+    def task_list_sections(custom_field_sections)
+        sections = [
             [
                 "Name and description",
                 "Website and social media",
@@ -16,10 +16,13 @@ module TaskListHelper
             ],
             [
                 "Special educational needs and disabilities",
-                "Suitable for",
-                # "Extra questions"
+                "Suitable for"
             ]
         ]
+
+        sections.last << "Extra questions" if custom_field_sections.length > 0
+
+        sections
     end
 
 end

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -17,7 +17,7 @@ module TaskListHelper
             [
                 "Special educational needs and disabilities",
                 "Suitable for",
-                "Extra questions"
+                # "Extra questions"
             ]
         ]
     end

--- a/app/helpers/taxonomies_helper.rb
+++ b/app/helpers/taxonomies_helper.rb
@@ -30,7 +30,7 @@ module TaxonomiesHelper
     end
 
 
-    def options_for_taxonomies_dropdown(taxonomies = Taxonomy.hash_tree, options=[], disabled=['265'])
+    def options_for_taxonomies_dropdown(taxonomies = Taxonomy.hash_tree, options=[])
         options ||= []
         taxonomies.each do |taxonomy, children|
           options << ['- ' * taxonomy.depth + taxonomy.name, taxonomy.id]

--- a/app/helpers/taxonomies_helper.rb
+++ b/app/helpers/taxonomies_helper.rb
@@ -3,13 +3,13 @@ module TaxonomiesHelper
     def tree_view(taxonomies)
         content_tag(:ul, class: "taxonomy-tree") do
             taxonomies.map do |t, children|
-
+                chld = children.present? ? tree_view(children) : ""
                 if params[:directory].present?
-                    "<li class='taxonomy-tree__item'>#{link_to(t.name, admin_taxonomy_path(t))} <span class='taxonomy-tree__count'>(#{t.services.in_directory(params[:directory]).size})</span></li>" + tree_view(children)
+                    "<li class='taxonomy-tree__item'>#{link_to(t.name, admin_taxonomy_path(t))} <span class='taxonomy-tree__count'>(#{t.services.in_directory(params[:directory]).size})</span></li>" + chld
                 else 
-                    "<li class='taxonomy-tree__item'>#{link_to(t.name, admin_taxonomy_path(t))} <span class='taxonomy-tree__count'>(#{t.services.size})</span></li>" + tree_view(children)
+                    "<li class='taxonomy-tree__item'>#{link_to(t.name, admin_taxonomy_path(t))} <span class='taxonomy-tree__count'>(#{t.services.size})</span></li>" + chld
                 end 
-            end.join.html_safe
+            end.join.html_safe 
         end
     end
 
@@ -28,4 +28,14 @@ module TaxonomiesHelper
             end
         end
     end
+
+
+    def options_for_taxonomies_dropdown(taxonomies = Taxonomy.hash_tree, options=[], disabled=['265'])
+        options ||= []
+        taxonomies.each do |taxonomy, children|
+          options << ['- ' * taxonomy.depth + taxonomy.name, taxonomy.id]
+          options_for_taxonomies_dropdown(children, options) if children.present?
+        end
+        options
+      end
 end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -1,7 +1,7 @@
 class CustomField < ApplicationRecord
   validates :key, presence: true, uniqueness: true
   validates_presence_of :field_type
-  belongs_to :custom_field_section
+  belongs_to :custom_field_section, counter_cache: :custom_fields_count
 
   def self.types
     [

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -16,10 +16,18 @@ class Service < ApplicationRecord
     }
   )
 
+  # fields
+  attr_accessor :skip_notify_watchers
+  attr_accessor :skip_add_parent_taxonomies
+  attr_accessor :skip_cost_option_validation
+  attr_accessor :skip_age_validation
+
   # validations
   validates :name, presence: true, uniqueness: true, length: { minimum: 2, maximum: 100 }
-  validate :validate_ages
-  validate :validate_freeness
+  validate :validate_ages, unless: :skip_age_validation
+  validate :validate_freeness, unless: :skip_cost_option_validation
+
+
 
   # associations
   belongs_to :organisation, counter_cache: true
@@ -74,8 +82,8 @@ class Service < ApplicationRecord
   scope :in_directory, -> (directory) { joins(:directories).where(directories: { name: directory }) }
 
   # callbacks
-  after_save :notify_watchers
-  after_save :add_parent_taxonomies
+  after_save :notify_watchers, unless: :skip_notify_watchers
+  before_save :add_parent_taxonomies, unless: :skip_add_parent_taxonomies
   before_save :skip_nested_indexes
   before_save :update_directories
 
@@ -265,25 +273,27 @@ class Service < ApplicationRecord
     self.directories_as_text = self.directories&.map{ |dir| dir.name }&.uniq&.sort&.join(", ")
   end
 
-  # include nested taxonomies in json representation by default
+  # include nested taxonomies in json representation by default (but can be overridden)
   def as_json(options={})
-    options[:include] = {
-      :organisation => {},
-      :locations => { 
-        methods: :geometry,
-        include: :accessibilities
-       },
-      :taxonomies => { methods: :slug },
-      :meta => {},
-      :contacts => {},
-      :local_offer => {},
-      :send_needs => {},
-      :suitabilities => {},
-      :cost_options => {},
-      :regular_schedules => {},
-      :links => {}
+    default_options = {
+      :include => {
+        :organisation => {},
+        :locations => { 
+          methods: :geometry,
+          include: :accessibilities
+        },
+        :taxonomies => { methods: :slug },
+        :meta => {},
+        :contacts => {},
+        :local_offer => {},
+        :send_needs => {},
+        :suitabilities => {},
+        :cost_options => {},
+        :regular_schedules => {},
+        :links => {}
+      }
     }
-    super
+    super(default_options.merge(options))
   end
 
   # fields that we don't care about for versioning purposes

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -24,17 +24,4 @@ class Taxonomy < ApplicationRecord
     def update_index
         UpdateIndexTaxonomiesJob.perform_later(self)
     end
-
-    def self.options_for_select
-        # order("LOWER(name)").map { |e| [e.name, e.id] }.unshift(["All taxonomies", ""])
-        Taxonomy.arranged_as_flat_array.map { |name, id| [name.html_safe, id] }.unshift(["All taxonomies", ""])
-    end
-
-    def self.arranged_as_flat_array(taxonomies = nil, level = 0)
-        taxonomies ||= Taxonomy.hash_tree
-      
-        taxonomies.map do |taxonomy, sub_taxonomies|
-          [["#{"&nbsp;" * level}#{taxonomy.name}", taxonomy.id], *arranged_as_flat_array(sub_taxonomies, level + 1)]
-        end.flatten(1)
-      end
 end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -26,6 +26,15 @@ class Taxonomy < ApplicationRecord
     end
 
     def self.options_for_select
-      order("LOWER(name)").map { |e| [e.name, e.id] }.unshift(["All taxonomies", ""])
+        # order("LOWER(name)").map { |e| [e.name, e.id] }.unshift(["All taxonomies", ""])
+        Taxonomy.arranged_as_flat_array.map { |name, id| [name.html_safe, id] }.unshift(["All taxonomies", ""])
     end
+
+    def self.arranged_as_flat_array(taxonomies = nil, level = 0)
+        taxonomies ||= Taxonomy.hash_tree
+      
+        taxonomies.map do |taxonomy, sub_taxonomies|
+          [["#{"&nbsp;" * level}#{taxonomy.name}", taxonomy.id], *arranged_as_flat_array(sub_taxonomies, level + 1)]
+        end.flatten(1)
+      end
 end

--- a/app/serializers/indexed_services_serializer.rb
+++ b/app/serializers/indexed_services_serializer.rb
@@ -21,7 +21,7 @@ class IndexedServicesSerializer < ActiveModel::Serializer
     :created_at,
     :status
 
-  has_many :target_directories do 
+  has_many :directories do 
     object.directories.map do |directory|
       { name: directory.name, label: directory.label }
     end

--- a/app/views/admin/custom_field_sections/index.html.erb
+++ b/app/views/admin/custom_field_sections/index.html.erb
@@ -13,7 +13,7 @@
   <table>
     <thead>
       <th>Name</th>
-      <th>Fields</th>
+      <th>Number of fields</th>
       <th>Visible to community users</th>
       <th>Exposed in API</th>
       <th>Sort order</th>
@@ -22,7 +22,7 @@
       <% @sections.each do |s| %>
         <tr>
           <td><%= link_to s.name, admin_custom_field_section_path(s) %></td>
-          <td><%= s.custom_fields.map{ |f| f.key }.join(", ") %></td>
+          <td><%= s.custom_fields.size %></td>
           <td>
             <% if s.public %>
               <%= image_tag "tick-black.svg", alt: "Yes" %>

--- a/app/views/admin/services/_filters.html.erb
+++ b/app/views/admin/services/_filters.html.erb
@@ -17,7 +17,7 @@
         <%= f.select :with_status, @filterrific.select_options[:with_status], {}, { class: "filters__select", data: { autosubmit: true } }  %>
 
         <%= f.label :in_taxonomy, "Taxonomy", class: "visually-hidden" %>
-        <%= f.select :in_taxonomy, @filterrific.select_options[:in_taxonomy], {}, { class: "filters__select", data: { autosubmit: true } }  %>
+        <%= f.select :in_taxonomy, options_for_taxonomies_dropdown, {}, { class: "filters__select", data: { autosubmit: true } }  %>
 
         <%= f.label :in_taxonomy, "Labels", class: "visually-hidden" %>
         <%= f.select :tagged_with, @filterrific.select_options[:tagged_with], {}, { class: "filters__select", data: { autosubmit: true } }  %>

--- a/app/views/admin/services/_filters.html.erb
+++ b/app/views/admin/services/_filters.html.erb
@@ -16,6 +16,9 @@
         <%= f.label :with_status, "Status", class: "visually-hidden" %>
         <%= f.select :with_status, @filterrific.select_options[:with_status], {}, { class: "filters__select", data: { autosubmit: true } }  %>
 
+        <%#= f.label :in_taxonomy, "Taxonomy", class: "visually-hidden" %>
+        <%#= f.select :in_taxonomy, options_for_taxonomies_dropdown(params[:directory].present? ? Taxonomy.filter_by_directory(params[:directory]) : Taxonomy.hash_tree), {include_blank: 'All taxonomies'}, { class: "filters__select", data: { autosubmit: true } }  %>
+
         <%= f.label :in_taxonomy, "Taxonomy", class: "visually-hidden" %>
         <%= f.select :in_taxonomy, options_for_taxonomies_dropdown, {}, { class: "filters__select", data: { autosubmit: true } }  %>
 
@@ -23,6 +26,7 @@
         <%= f.select :tagged_with, @filterrific.select_options[:tagged_with], {}, { class: "filters__select", data: { autosubmit: true } }  %>
 
     </div>
+
 </details>
 
 <header class="actions">

--- a/app/views/admin/services/_filters.html.erb
+++ b/app/views/admin/services/_filters.html.erb
@@ -8,8 +8,6 @@
     <summary class="filters__control" aria-expanded="false">Filters</summary>
     <div class="filters__body">
 
-
-
         <%= f.label :sorted_by, "Sort", class: "visually-hidden" %>
         <%= f.select :sorted_by, @filterrific.select_options[:sorted_by], {}, { class: "filters__select", data: { autosubmit: true }, disabled: params.dig(:filterrific, :search).present? } %>
 
@@ -20,7 +18,7 @@
         <%#= f.select :in_taxonomy, options_for_taxonomies_dropdown(params[:directory].present? ? Taxonomy.filter_by_directory(params[:directory]) : Taxonomy.hash_tree), {include_blank: 'All taxonomies'}, { class: "filters__select", data: { autosubmit: true } }  %>
 
         <%= f.label :in_taxonomy, "Taxonomy", class: "visually-hidden" %>
-        <%= f.select :in_taxonomy, options_for_taxonomies_dropdown, {}, { class: "filters__select", data: { autosubmit: true } }  %>
+        <%= f.select :in_taxonomy, options_for_taxonomies_dropdown, {include_blank: 'All taxonomies'}, { class: "filters__select", data: { autosubmit: true } }  %>
 
         <%= f.label :in_taxonomy, "Labels", class: "visually-hidden" %>
         <%= f.select :tagged_with, @filterrific.select_options[:tagged_with], {}, { class: "filters__select", data: { autosubmit: true } }  %>

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -8,8 +8,9 @@
 <% content_for :precontent do%>
   <nav class="breadcrumbs">
     <ul class="breadcrumbs__inner container">
-      <li class="breadcrumbs__link"><a href="/">Home</a></li>
-      <li class="breadcrumbs__link">Edit Settings</li>
+      <li class="breadcrumbs__link"><%= link_to "Home", admin_root_path %></li>
+      <li class="breadcrumbs__link"><%= link_to "Settings", admin_settings_path %></li>
+      <li class="breadcrumbs__link">Edit</li>
     </ul>
   </nav>
 <% end %>
@@ -24,82 +25,25 @@
 
 
 <div class="with-sidebar">
-
+ 
 
     <div>
       <%= form_for(@admin_settings, url: admin_settings_path, html: { method: :patch } ) do |f| %>
 
-      <%= render "shared/errors", model: @admin_settings %>
+        <%= render "shared/errors", model: @admin_settings %>
 
-      <%= render "shared/collapsible", name: "Application settings", id: "settings-application " do %>
-         <div class="field-section">
-          <div class="field">
-            <%= f.label :outpost_title, class: "field__label" %>
-            <p class="field__hint">The title of this install. Shown in the title and header for all users.</p>
-            <%= f.text_field :outpost_title, value: Setting.outpost_title, class: "field__input" %>
-          </div>
-          <div class="field">
-            <%= f.label :outpost_sub_title, class: "field__label" %>
-            <p class="field__hint">The sub title for this install. Shown in the site hea &lt;Outpost Title&gt; | &lt;Outpost sub title&gt;</p>
-            <%= f.text_field :outpost_sub_title, value: Setting.outpost_sub_title, class: "field__input" %>
-          </div>
-          <div class="field">
-            <%= f.label :outpost_instance_name, class: "field__label" %>
-            <p class="field__hint">The name of this instance, appears on emails, for example "You have been invited to join &lt;our directory service&gt;"</p>
-            <%= f.text_field :outpost_instance_name, value: Setting.outpost_instance_name, class: "field__input" %>
-          </div>
-        </div>
-      <% end %>
+        <%= render "shared/collapsible", name: "Application settings", id: "settings-application " do %>
+          <%= render "admin/settings/editors/application", f: f %>
+        <% end %>
 
-       <%= render "shared/collapsible", name: "Application theming", id: "settings-theming " do %>
-        <div class="field-section">
-          <div class="field">
-            <%= f.label :primary_color, class: "field__label" %>
-            <p class="field__hint">The primary colour used in this outpost install. Mostly used in the header. The default is <em>#2c2d84</em></p>
-            <div class="field__color">
-            <%= f.color_field :primary_color, value: Setting.primary_color, class: "field__color-input" %>
-            </div>
-            <p><strong><%= Setting.primary_color %></strong></p>
-          </div>
-          <div class="field">
-            <%= f.label :outpost_logo, class: "field__label" %>
-            <p class="field__hint">The logo used for outpost</p>
-            <%= f.file_field :outpost_logo, value: Setting.outpost_logo, class: "field__input" %>
-          </div>
-          <% if FileUpload.find_by(var: 'outpost_logo') %>
-            <p class="settings-logo-preview" style="background-color: <%= Setting.primary_color %>">
-                <%= image_tag(url_for(FileUpload.find_by(var: 'outpost_logo').file))%>
-            </p>
-          <% end %>
-          <div class="field">
-            <%= f.label :outpost_logo_height, class: "field__label" %>
-            <p class="field__hint">The height of the logo.</p>
-            <%= f.text_field :outpost_logo_height, value: Setting.outpost_logo_height, class: "field__input" %>
-          </div>
-          <div class="field">
-            <%= f.label :outpost_logo_height_mobile, class: "field__label" %>
-            <p class="field__hint">The height of the logo when on mobile view.</p>
-            <%= f.text_field :outpost_logo_height_mobile, value: Setting.outpost_logo_height_mobile, class: "field__input" %>
-          </div>
-        </div>
-      <% end %>
+        <%= render "shared/collapsible", name: "Application theming", id: "settings-theming " do %>
+          <%= render "admin/settings/editors/theming", f: f %>
+        <% end %>
 
+        <%= render "shared/collapsible", name: "Outpost features", id: "settings-features " do %>
+          <%= render "admin/settings/editors/features", f: f %>
+        <% end %>
 
-       <%= render "shared/collapsible", name: "Outpost features", id: "settings-features " do %>
-         <div class="field-section">
-            <div class="field field--span-two-cols">
-              <div class="checkbox">
-              <%= f.check_box :feature_wysiwyg, class: "checkbox__input"%>
-              <%= f.label :feature_wysiwyg, class: "checkbox__label" do %>
-                  Enable WYSIWYG editor functionality for service description fields.
-              <% end %>
-              </div>
-            </div>
-        </div>
-      <% end %>
-
-
- 
         <div class="form-actions">
           <%= f.submit "Save", class: "button" %>
         </div>

--- a/app/views/admin/settings/editors/_application.html.erb
+++ b/app/views/admin/settings/editors/_application.html.erb
@@ -1,0 +1,17 @@
+<div class="field-section">
+<div class="field">
+  <%= f.label :outpost_title, class: "field__label" %>
+  <p class="field__hint">The title of this install. Shown in the title and header for all users.</p>
+  <%= f.text_field :outpost_title, value: Setting.outpost_title, class: "field__input" %>
+</div>
+<div class="field">
+  <%= f.label :outpost_sub_title, class: "field__label" %>
+  <p class="field__hint">The sub title for this install. Shown in the site header &lt;Outpost Title&gt; | &lt;Outpost sub title&gt;</p>
+  <%= f.text_field :outpost_sub_title, value: Setting.outpost_sub_title, class: "field__input" %>
+</div>
+<div class="field">
+  <%= f.label :outpost_instance_name, class: "field__label" %>
+  <p class="field__hint">The name of this instance, appears on emails, for example "You have been invited to join &lt;our directory service&gt;"</p>
+  <%= f.text_field :outpost_instance_name, value: Setting.outpost_instance_name, class: "field__input" %>
+</div>
+</div>

--- a/app/views/admin/settings/editors/_features.html.erb
+++ b/app/views/admin/settings/editors/_features.html.erb
@@ -1,0 +1,10 @@
+<div class="field-section">
+    <div class="field field--span-two-cols">
+      <div class="checkbox">
+        <%= f.check_box :feature_wysiwyg, class: "checkbox__input"%>
+        <%= f.label :feature_wysiwyg, class: "checkbox__label" do %>
+            Enable WYSIWYG editor functionality for service description fields.
+        <% end %>
+      </div>
+    </div>
+</div>

--- a/app/views/admin/settings/editors/_theming.html.erb
+++ b/app/views/admin/settings/editors/_theming.html.erb
@@ -1,0 +1,30 @@
+<div class="field-section">
+  <div class="field">
+    <%= f.label :primary_color, class: "field__label" %>
+    <p class="field__hint">The primary colour used in this outpost install. Mostly used in the header. The default is <em>#2c2d84</em></p>
+    <div class="field__color">
+    <%= f.color_field :primary_color, value: Setting.primary_color, class: "field__color-input" %>
+    </div>
+    <p><strong><%= Setting.primary_color %></strong></p>
+  </div>
+  <div class="field">
+    <%= f.label :outpost_logo, class: "field__label" %>
+    <p class="field__hint">The logo used for outpost</p>
+    <%= f.file_field :outpost_logo, value: Setting.outpost_logo, class: "field__input" %>
+  </div>
+  <% if FileUpload.find_by(var: 'outpost_logo') %>
+    <p class="settings-logo-preview" style="background-color: <%= Setting.primary_color %>">
+        <%= image_tag(url_for(FileUpload.find_by(var: 'outpost_logo').file))%>
+    </p>
+  <% end %>
+  <div class="field">
+    <%= f.label :outpost_logo_height, class: "field__label" %>
+    <p class="field__hint">The height of the logo.</p>
+    <%= f.text_field :outpost_logo_height, value: Setting.outpost_logo_height, class: "field__input" %>
+  </div>
+  <div class="field">
+    <%= f.label :outpost_logo_height_mobile, class: "field__label" %>
+    <p class="field__hint">The height of the logo when on mobile view.</p>
+    <%= f.text_field :outpost_logo_height_mobile, value: Setting.outpost_logo_height_mobile, class: "field__input" %>
+  </div>
+</div>

--- a/app/views/admin/settings/show.html.erb
+++ b/app/views/admin/settings/show.html.erb
@@ -1,0 +1,36 @@
+<% content_for :title do %>Settings | <% end %>
+
+<% content_for :header do %>
+<h1 class="page-header__title two-thirds">Settings</h1>
+<% end %>
+
+
+<% content_for :precontent do%>
+  <nav class="breadcrumbs">
+    <ul class="breadcrumbs__inner container">
+      <li class="breadcrumbs__link"><%= link_to "Home", admin_root_path %></li>
+      <li class="breadcrumbs__link">Settings</li>
+    </ul>
+  </nav>
+<% end %> 
+   
+<div class="with-sidebar">
+
+       
+    <div>  
+      <p>The settings page allows to to configure your Outpost installation. It is currently only accessible by users with the superadmin role. This role can only be set by a server administrator.</p>
+      <p><%= link_to "Edit settings", edit_admin_settings_path, class: "button button--small" %></p>
+
+ 
+      
+      <h2>Tools</h2>
+      <p>The following are links to tools that are useful for managing your Outpost installation and its data.</p>
+      <p><%= link_to "Bulk add taxonomies", admin_settings_tools_bulk_add_taxonomies_path %> <br /> This tool allows you to add an additional taxonomy to a selection of services</p>
+
+
+    </div>
+
+    <aside class="with-sidebar__sidebar">
+
+    </aside>
+</div>

--- a/app/views/admin/taxonomies/_fields.html.erb
+++ b/app/views/admin/taxonomies/_fields.html.erb
@@ -5,7 +5,7 @@
 
 <div class="field">
     <%= s.label :parent_id, "Parent", class: "field__label" %>
-    <%= s.collection_select( :parent_id, @possible_parents, :id, :name, {include_blank: ""}, class: "field__input") %>
+    <%= s.select( :parent_id, options_for_select(options_for_taxonomies_dropdown, selected: s.object.parent_id, disabled: params[:id]), {include_blank: ""}, class: "field__input") %>
 </div>
 
 <div class="field">

--- a/app/views/admin/tools/bulk_add_taxonomies/show.html.erb
+++ b/app/views/admin/tools/bulk_add_taxonomies/show.html.erb
@@ -1,0 +1,90 @@
+<% content_for :title do %>Bulk add taxonomies | <% end %>
+
+<% content_for :header do %>
+<h1 class="page-header__title two-thirds">Bulk add taxonomies</h1>
+<% end %>
+
+
+<% content_for :precontent do%>
+  <nav class="breadcrumbs">
+    <ul class="breadcrumbs__inner container">
+      <li class="breadcrumbs__link"><%= link_to "Home", admin_root_path %></li>
+      <li class="breadcrumbs__link"><%= link_to "Settings", admin_settings_path %></li>
+      <li class="breadcrumbs__link">Tools</li>
+      <li class="breadcrumbs__link">Bulk add taxonomies</li>
+    </ul>
+  </nav>
+<% end %> 
+
+
+<div class="with-sidebar">
+
+
+    <div>
+      <p>This tool allows you to add new taxonomies to a selection of services. <br />
+      Please note some actions may take a <strong>long time</strong> as every record is updated and added to the activity log.</p> 
+      
+      <p>Email alerts are <strong>not</strong> sent to watchers. <br />
+      We <strong>don't update the mongo database</strong> so you will need to run the build_public_index task afterwards. <br />
+      Activity records are <strong>created manually</strong>.
+      </p>
+
+      <p>After running this tool you will need to run the <em>build_public_index</em> and <em>update_counters</em> jobs</p>
+
+      <% if Taxonomy.any? %>
+
+        <%= form_with url: admin_settings_tools_bulk_add_taxonomies_path, method: :patch, data: {warn_unsaved_changes: true}, builder: OutpostFormBuilder do |s| %>
+
+          <% if @errors.any? %>
+              <div class="error">
+                  <h2 class="error__title"><%= pluralize(@errors.count, "error") %> occured</h2>
+                  <p>The following services could not be updated, please try again or update them manually</p>
+                  <ul class="error__list">
+                      <% @errors.each do |e| %>
+                          <li>
+                            <%= link_to e[:name] || 'Unknown service name', admin_service_path(e[:id]) %>  
+                            <p>
+                              <ul>
+                                <% e[:messages].each do |m| %> 
+                                  <li><%= m.html_safe %></li>
+                                <% end %>
+                              </ul>
+                            </p>
+                          </li>      
+                      <% end %>
+                  </ul>
+              </div>
+          <% end %>
+
+
+          <h2>Services</h2>
+
+          <div class="field field--required">
+            <%= label_tag :taxonomy, "Services in this taxonomy", class: "field__label" %>
+            <%= select_tag :taxonomy, options_for_select(options_for_taxonomies_dropdown()), { class: "field__input", include_blank: true, required: true}  %>
+          </div>
+
+          <h2>Taxonomies</h2>
+
+          <%= render "shared/editors/taxonomies", s: s %>
+      
+          <div class="form-actions">
+            <%= s.submit "Add new taxonomies", class: "button" %>
+          </div>
+
+        <% end %>
+
+
+      <% else %>
+        <p>
+          No taxonomies set up yet.
+          <%= link_to 'Create some taxonomies', admin_taxonomies_path %>
+        </p>
+      <% end %>
+
+    </div>
+
+    <aside class="with-sidebar__sidebar">
+
+    </aside>
+</div>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -53,6 +53,11 @@
                     <%= render "task_list_item", s: s %>
                 </li>
             <% end %>
+             <% if @custom_field_sections.length > 0 %>
+                    <li class="task-list__item">
+                        <%= render "task_list_item", s: "Extra questions" %>
+                    </li>
+                <% end %>
         </ul>
     </li>
 

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -13,9 +13,9 @@
 
 <% if @currently_creating %>
     <div class="task-list-summary">
-        <% if @completion_count < task_list_sections.flatten.count  %>
+        <% if @completion_count < task_list_sections(@custom_field_sections).flatten.count  %>
             <h2>Submission incomplete</h2>
-            <p>You've completed <%= @completion_count %> of <%= task_list_sections.flatten.count %> sections.</p>
+            <p>You've completed <%= @completion_count %> of <%= task_list_sections(@custom_field_sections).flatten.count %> sections.</p>
         <% else %>
             <h2>Ready to submit</h2>
             <p>You can now finish and send this application.</p>
@@ -28,7 +28,7 @@
     <li class="task-list__section">
         <h2 class="task-list__heading">Basic information</h2>
         <ul class="task-list__sublist">
-            <% task_list_sections[0].each do |s| %>
+            <% task_list_sections(@custom_field_sections)[0].each do |s| %>
                 <li class="task-list__item">
                     <%= render "task_list_item", s: s %>
                 </li>
@@ -38,7 +38,7 @@
     <li class="task-list__section">
         <h2 class="task-list__heading">Help people find your service</h2>
         <ul class="task-list__sublist">
-            <% task_list_sections[1].each do |s| %>
+            <% task_list_sections(@custom_field_sections)[1].each do |s| %>
                 <li class="task-list__item">
                     <%= render "task_list_item", s: s %>
                 </li>
@@ -48,16 +48,11 @@
     <li class="task-list__section">
         <h2 class="task-list__heading">Extra information</h2>
         <ul class="task-list__sublist">
-            <% task_list_sections[2].each do |s| %>
+            <% task_list_sections(@custom_field_sections)[2].each do |s| %>
                 <li class="task-list__item">
                     <%= render "task_list_item", s: s %>
                 </li>
             <% end %>
-             <% if @custom_field_sections.length > 0 %>
-                    <li class="task-list__item">
-                        <%= render "task_list_item", s: "Extra questions" %>
-                    </li>
-                <% end %>
         </ul>
     </li>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,11 +3,7 @@
     <div class="<%= "container" unless full_width %> site-header__inner">
         <div class="site-header__masthead">
             <div class="site-header__logo-link">
-            <% if FileUpload.find_by(var: 'outpost_logo') %>
-            <%= image_tag(url_for(FileUpload.find_by(var: 'outpost_logo').file), alt: Setting.outpost_title, class: "site-header__logo") %>
-            <% else %>
-            <%= image_tag("logo-outpost.svg", alt: "Outpost", class: "site-header__logo") %>
-            <% end %>
+            <%= get_header_image %>
             </div>
         </div>
 

--- a/app/views/shared/editors/_taxonomies.html.erb
+++ b/app/views/shared/editors/_taxonomies.html.erb
@@ -1,0 +1,38 @@
+<div class="tabs">
+    <ul class="tabs__nav">
+        <% Taxonomy.roots.each do |t| %>
+            <li class="tabs__nav-item">
+                <a href="#" class="tabs__nav-link"><%= t.name %></a>
+            </li>
+        <% end %>
+    </ul>
+    <% tree = Taxonomy.hash_tree %>
+    <%= s.collection_check_boxes( :taxonomy_ids, tree.keys, :id, :name) do |c| %>
+        <div class="tabs__panel">
+            <div class="tabs__checkbox-area">
+ 
+            <div class="field checkbox checkbox--small">
+                <%= c.check_box class: "checkbox__input" %>
+                <%= c.label class: "checkbox__label" %>
+            </div>
+
+                <% branch = tree[c.object] %>
+                <%= s.collection_check_boxes( :taxonomy_ids, branch.keys, :id, :name) do |d| %>
+                    <div class="field checkbox checkbox--small checkbox--level-1">
+                        <%= d.check_box class: "checkbox__input" %>
+                        <%= d.label class: "checkbox__label" %>
+                    </div>
+                    <% leaf = branch[d.object] %>
+                    <%= s.collection_check_boxes( :taxonomy_ids, leaf.keys, :id, :name) do |e| %>
+                        <div class="field checkbox checkbox--small checkbox--level-2">
+                            <%= e.check_box class: "checkbox__input" %>
+                            <%= e.label class: "checkbox__label" %>
+                        </div>
+                    <% end %>
+                <% end %>
+            </div>
+            <button class="inline-button" type="button" data-taxonomies-select-all>Select all</button>
+            <button class="inline-button" type="button" data-taxonomies-deselect-all>Deselect all</button>
+        </div>
+    <% end %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :public_google
+  config.active_storage.service = ENV['GCP_PROJECT_ID'].present? ? :public_google : :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,11 @@ Rails.application.routes.draw do
       post :reset, on: :member
       put :reactivate, on: :member
     end
-    resource :settings, only: [:edit, :update]
+    resource :settings, only: [:show, :edit, :update] do
+      namespace :tools do 
+          resource :bulk_add_taxonomies, only: [:show, :update]
+      end 
+    end
     resources :send_needs, except: [:edit, :show, :destroy, :update] do
       collection do
         post 'create_defaults', to: "send_needs#create_defaults"

--- a/db/migrate/20240510133524_add_custom_fields_count_to_custom_field_sections.rb
+++ b/db/migrate/20240510133524_add_custom_fields_count_to_custom_field_sections.rb
@@ -1,0 +1,5 @@
+class AddCustomFieldsCountToCustomFieldSections < ActiveRecord::Migration[6.0]
+  def change
+    add_column :custom_field_sections, :custom_fields_count, :integer
+  end
+end

--- a/db/migrate/20240510133929_reset_all_custom_field_sections_cache_counters.rb
+++ b/db/migrate/20240510133929_reset_all_custom_field_sections_cache_counters.rb
@@ -1,0 +1,10 @@
+class ResetAllCustomFieldSectionsCacheCounters < ActiveRecord::Migration[6.0]
+  def up
+    CustomFieldSection.all.each do |section|
+      CustomFieldSection.reset_counters(section.id, :custom_fields)
+    end
+  end
+  def down
+    # no rollback needed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_24_230543) do
+ActiveRecord::Schema.define(version: 2024_05_10_133929) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
@@ -77,6 +76,7 @@ ActiveRecord::Schema.define(version: 2023_08_24_230543) do
     t.boolean "public"
     t.integer "sort_order"
     t.boolean "api_public"
+    t.integer "custom_fields_count"
   end
 
   create_table "custom_fields", force: :cascade do |t|
@@ -285,7 +285,6 @@ ActiveRecord::Schema.define(version: 2023_08_24_230543) do
     t.string "postcode"
     t.string "ward"
     t.string "family_centre"
-    t.string "area"
   end
 
   create_table "send_needs", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -61,11 +61,27 @@ if seed_dummy_data
         location.save
     end
 
-    10.times do 
+
+    # create nested taxonomies - chance of subcategories being generated is different at each level
+    def create_taxonomy(level = 0, parent_id = nil)
+        return if level >= 4
+      
         taxon = Taxonomy.create!({
-            name: Faker::Lorem.words(number: rand(1...5)).join(' ').capitalize
+          name: Faker::Lorem.words(number: rand(2...5)).join(' ').capitalize,
+          parent_id: parent_id
         })
+      
+        case level
+        when 0
+          rand(2..10).times { create_taxonomy(level + 1, taxon.id) } if rand < 0.50
+        when 1
+          rand(3..15).times { create_taxonomy(level + 1, taxon.id) } if rand < 0.2
+        when 2
+          rand(1..3).times { create_taxonomy(level + 1, taxon.id) } if rand < 0.15
+        end
     end
+      
+    5.times { create_taxonomy }
 
     10.times do
         org = Organisation.create!({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       # RAILS_ENV: production
       OFSTED_FEED_API_ENDPOINT: ${OFSTED_FEED_API_ENDPOINT:-https://test-ofsted-feed.stub} # this is not a real url, we just need an env variable set for the stub to work in tests
       SHOW_ENV_BANNER: ${SHOW_ENV_BANNER:-outpost docker development}
-      DB_URI: ${DB_URI:-mongodb://mongo:27017/outpost_api_development}
+      DB_URI: mongodb://${MONGO_INITDB_USERNAME:-outpost}:${MONGO_INITDB_PASSWORD:-password}@mongo/${MONGO_INITDB_DATABASE:-outpost_api_development}
       DATABASE_URL: ${DATABASE_URL:-postgresql://outpost:password@postgres:5432/outpost?}
     networks:
       - external_network

--- a/lib/tasks/services/add_parent_taxonomies.rake
+++ b/lib/tasks/services/add_parent_taxonomies.rake
@@ -1,0 +1,10 @@
+# bin/bundle exec rake service:add_parent_taxonomies
+
+namespace :service do
+  desc 'Add parent taxonomies to each service'
+  task add_parent_taxonomies: :environment do
+    Service.find_each(batch_size: 1000) do |service|
+      service.add_parent_taxonomies
+    end
+  end
+end

--- a/spec/features/community_user_managing_services_spec.rb
+++ b/spec/features/community_user_managing_services_spec.rb
@@ -4,6 +4,7 @@ feature 'Community user managing services', type: :feature do
   let!(:suitabilities) { FactoryBot.create_list :suitability, 5 }
   let!(:taxonomies) { FactoryBot.create_list :taxonomy, 5 }
 
+
   before do
     user = FactoryBot.create :user
     login_as user
@@ -15,62 +16,82 @@ feature 'Community user managing services', type: :feature do
     expect(page).to have_content("Your users")
   end
 
-  scenario 'I can add a service to the directory' do
-    click_link_or_button('Add Service, Event or Activity')
+  context 'With custom fields available to provider' do
+    let!(:custom_field_section) { FactoryBot.create :custom_field_section, public: true }
+    let!(:custom_field) { FactoryBot.create :custom_field, custom_field_section: custom_field_section }
 
-    fill_in('What is your service or activity called?', with: 'Example service')
-    fill_in('Describe your service', with: 'Example description here')
-    click_link_or_button('Continue')
+    scenario 'I can add a service to the directory' do
+      click_link_or_button('Add Service, Event or Activity')
 
-    expect(page).to have_content("List a new service")
-    expect(page).to have_content("Submission incomplete")
+      fill_in('What is your service or activity called?', with: 'Example service')
+      fill_in('Describe your service', with: 'Example description here')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Website and social media')
-    fill_in('Website', with: 'http://example.com')
-    click_link_or_button('Continue')
+      expect(page).to have_content("List a new service")
+      expect(page).to have_content("Submission incomplete")
+      expect(page).to have_content("You've completed 1 of 11 sections.")
+      expect(page).to have_content("Extra questions")
 
-    click_link_or_button('Visibility')
-    uncheck("Make this service publicly visible")
-    check("Make this service publicly visible")
-    fill_in('From', with: '01/01/2020')
-    fill_in('To', with: '01/01/2021')
-    click_link_or_button('Continue')
+      click_link_or_button('Website and social media')
+      fill_in('Website', with: 'http://example.com')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Opening times')
-    click_link_or_button('Continue')
+      click_link_or_button('Visibility')
+      uncheck("Make this service publicly visible")
+      check("Make this service publicly visible")
+      fill_in('From', with: '01/01/2020')
+      fill_in('To', with: '01/01/2021')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Fees')
-    click_link_or_button('Continue')
+      click_link_or_button('Opening times')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Locations')
-    click_link_or_button('Continue')
+      click_link_or_button('Fees')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Contacts')
-    click_link_or_button('Continue')
+      click_link_or_button('Locations')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Ages')
-    fill_in('Minimum', with: '5')
-    fill_in('Maximum', with: '10')
-    click_link_or_button('Continue')
+      click_link_or_button('Contacts')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Special educational needs and disabilities')
-    check("This service is part of the SEND local offer")
-    uncheck("This service is part of the SEND local offer")
-    click_link_or_button('Continue')
+      click_link_or_button('Ages')
+      fill_in('Minimum', with: '5')
+      fill_in('Maximum', with: '10')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Suitable for')
-    check suitabilities.first.name
-    click_link_or_button('Continue')
+      click_link_or_button('Special educational needs and disabilities')
+      check("This service is part of the SEND local offer")
+      uncheck("This service is part of the SEND local offer")
+      click_link_or_button('Continue')
 
-    click_link_or_button('Extra questions')
-    click_link_or_button('Continue')
+      click_link_or_button('Suitable for')
+      check suitabilities.first.name
+      click_link_or_button('Continue')
 
-    expect(page).to have_content("Ready to submit")
-    click_link_or_button('Finish and send')
-    expect(page).to have_content("Your service has been successfully submitted")
+      click_link_or_button('Extra questions')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Return to dashboard')
-    expect(page).to have_content("Example service")
-    expect(page).to have_content("Pending")
+      expect(page).to have_content("Ready to submit")
+      click_link_or_button('Finish and send')
+      expect(page).to have_content("Your service has been successfully submitted")
+
+      click_link_or_button('Return to dashboard')
+
+      expect(page).to have_content("Example service")
+      expect(page).to have_content("Pending")
+    end
+  end
+
+  context 'With no custom fields available to provider' do
+    scenario 'I see no option for extra questions' do
+      click_link_or_button('Add Service, Event or Activity')
+      fill_in('What is your service or activity called?', with: 'Example service')
+      fill_in('Describe your service', with: 'Example description here')
+      click_link_or_button('Continue')
+
+      expect(page).to have_content("You've completed 1 of 10 sections.")
+      expect(page).to_not have_content("Extra questions")
+    end
   end
 end

--- a/spec/requests/api/get_taxonomies_spec.rb
+++ b/spec/requests/api/get_taxonomies_spec.rb
@@ -35,13 +35,13 @@ describe 'GET taxonomies endpoint', type: :request do
       end
 
       it 'can filter by directory' do
-        get "/api/v1/taxonomies?directory=#{directory_a.label}"
+        get "/api/v1/taxonomies?directory[]=#{directory_a.label}"
         response_body = JSON.parse(response.body)
 
         root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
         expect(root_taxonomy_ids).to match_array([root_taxonomy.id])
 
-        get "/api/v1/taxonomies?directory=#{directory_b.label}"
+        get "/api/v1/taxonomies?directory[]=#{directory_b.label}"
         response_body = JSON.parse(response.body)
 
         root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
@@ -51,7 +51,7 @@ describe 'GET taxonomies endpoint', type: :request do
       context 'filtering by an empty directory' do
         let!(:directory_c) { FactoryBot.create(:directory, name: "Directory C", label: "c") }
         it 'returns no results' do
-          get "/api/v1/taxonomies?directory=#{directory_c.label}"
+          get "/api/v1/taxonomies?directory[]=#{directory_c.label}"
           response_body = JSON.parse(response.body)
           expect(response_body).to match_array([])
         end
@@ -59,7 +59,7 @@ describe 'GET taxonomies endpoint', type: :request do
 
       context 'filtering by a directory that does not exist' do
         it 'returns all results' do
-          get "/api/v1/taxonomies?directory=not-a-real-directory"
+          get "/api/v1/taxonomies?directory[]=not-a-real-directory"
           response_body = JSON.parse(response.body)
 
           root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}

--- a/spec/requests/api/get_taxonomies_spec.rb
+++ b/spec/requests/api/get_taxonomies_spec.rb
@@ -35,13 +35,13 @@ describe 'GET taxonomies endpoint', type: :request do
       end
 
       it 'can filter by directory' do
-        get "/api/v1/taxonomies?directory[]=#{directory_a.label}"
+        get "/api/v1/taxonomies?directories[]=#{directory_a.label}"
         response_body = JSON.parse(response.body)
 
         root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
         expect(root_taxonomy_ids).to match_array([root_taxonomy.id])
 
-        get "/api/v1/taxonomies?directory[]=#{directory_b.label}"
+        get "/api/v1/taxonomies?directories[]=#{directory_b.label}"
         response_body = JSON.parse(response.body)
 
         root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}
@@ -51,7 +51,7 @@ describe 'GET taxonomies endpoint', type: :request do
       context 'filtering by an empty directory' do
         let!(:directory_c) { FactoryBot.create(:directory, name: "Directory C", label: "c") }
         it 'returns no results' do
-          get "/api/v1/taxonomies?directory[]=#{directory_c.label}"
+          get "/api/v1/taxonomies?directories[]=#{directory_c.label}"
           response_body = JSON.parse(response.body)
           expect(response_body).to match_array([])
         end
@@ -59,7 +59,7 @@ describe 'GET taxonomies endpoint', type: :request do
 
       context 'filtering by a directory that does not exist' do
         it 'returns all results' do
-          get "/api/v1/taxonomies?directory[]=not-a-real-directory"
+          get "/api/v1/taxonomies?directories[]=not-a-real-directory"
           response_body = JSON.parse(response.body)
 
           root_taxonomy_ids = response_body.map{|taxonomy| taxonomy["id"]}


### PR DESCRIPTION
- see #327

notable possible **breaking** changes:

* `/api/v1/taxonomies` can now fetch one or more results:
  * `http://localhost:3000/api/v1/taxonomies?directories[]=bfis` 
  * `http://localhost:3000/api/v1/taxonomies?directories[]=bod` 
  * `http://localhost:3000/api/v1/taxonomies?directories[]=bfis&directories[]=bod`
* indexed services are passed over with `directories` instead of `target_directories` (for consistency)