### PR TITLE
Feature/dont show extra questions if there arent any

### DIFF
--- a/app/controllers/admin/custom_field_sections_controller.rb
+++ b/app/controllers/admin/custom_field_sections_controller.rb
@@ -3,7 +3,7 @@ class Admin::CustomFieldSectionsController < Admin::BaseController
   before_action :set_section, only: [:show, :update, :destroy]
 
   def index
-    @sections = CustomFieldSection.includes(:custom_fields).all
+    @sections = CustomFieldSection.all
   end
 
   def new

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -61,8 +61,9 @@ class ServicesController < ApplicationController
 
     def set_service
         @service = current_user.organisation.services.find(params[:id] || params[:service_id])
-        @custom_field_sections = CustomFieldSection.includes(:custom_fields).visible_to(current_user)
+        @custom_field_sections = CustomFieldSection.visible_to(current_user).where('custom_fields_count > 0')
     end
+
 
     def service_params
         result_params = params.require(:service).permit(

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -1,7 +1,7 @@
 module TaskListHelper
 
-    def task_list_sections
-        [
+    def task_list_sections(custom_field_sections)
+        sections = [
             [
                 "Name and description",
                 "Website and social media",
@@ -16,10 +16,13 @@ module TaskListHelper
             ],
             [
                 "Special educational needs and disabilities",
-                "Suitable for",
-                # "Extra questions"
+                "Suitable for"
             ]
         ]
+
+        sections.last << "Extra questions" if custom_field_sections.length > 0
+
+        sections
     end
 
 end

--- a/app/helpers/task_list_helper.rb
+++ b/app/helpers/task_list_helper.rb
@@ -17,7 +17,7 @@ module TaskListHelper
             [
                 "Special educational needs and disabilities",
                 "Suitable for",
-                "Extra questions"
+                # "Extra questions"
             ]
         ]
     end

--- a/app/models/custom_field.rb
+++ b/app/models/custom_field.rb
@@ -1,7 +1,7 @@
 class CustomField < ApplicationRecord
   validates :key, presence: true, uniqueness: true
   validates_presence_of :field_type
-  belongs_to :custom_field_section
+  belongs_to :custom_field_section, counter_cache: :custom_fields_count
 
   def self.types
     [

--- a/app/views/admin/custom_field_sections/index.html.erb
+++ b/app/views/admin/custom_field_sections/index.html.erb
@@ -13,7 +13,7 @@
   <table>
     <thead>
       <th>Name</th>
-      <th>Fields</th>
+      <th>Number of fields</th>
       <th>Visible to community users</th>
       <th>Exposed in API</th>
       <th>Sort order</th>
@@ -22,7 +22,7 @@
       <% @sections.each do |s| %>
         <tr>
           <td><%= link_to s.name, admin_custom_field_section_path(s) %></td>
-          <td><%= s.custom_fields.map{ |f| f.key }.join(", ") %></td>
+          <td><%= s.custom_fields.size %></td>
           <td>
             <% if s.public %>
               <%= image_tag "tick-black.svg", alt: "Yes" %>

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -53,6 +53,11 @@
                     <%= render "task_list_item", s: s %>
                 </li>
             <% end %>
+             <% if @custom_field_sections.length > 0 %>
+                    <li class="task-list__item">
+                        <%= render "task_list_item", s: "Extra questions" %>
+                    </li>
+                <% end %>
         </ul>
     </li>
 

--- a/app/views/services/show.html.erb
+++ b/app/views/services/show.html.erb
@@ -13,9 +13,9 @@
 
 <% if @currently_creating %>
     <div class="task-list-summary">
-        <% if @completion_count < task_list_sections.flatten.count  %>
+        <% if @completion_count < task_list_sections(@custom_field_sections).flatten.count  %>
             <h2>Submission incomplete</h2>
-            <p>You've completed <%= @completion_count %> of <%= task_list_sections.flatten.count %> sections.</p>
+            <p>You've completed <%= @completion_count %> of <%= task_list_sections(@custom_field_sections).flatten.count %> sections.</p>
         <% else %>
             <h2>Ready to submit</h2>
             <p>You can now finish and send this application.</p>
@@ -28,7 +28,7 @@
     <li class="task-list__section">
         <h2 class="task-list__heading">Basic information</h2>
         <ul class="task-list__sublist">
-            <% task_list_sections[0].each do |s| %>
+            <% task_list_sections(@custom_field_sections)[0].each do |s| %>
                 <li class="task-list__item">
                     <%= render "task_list_item", s: s %>
                 </li>
@@ -38,7 +38,7 @@
     <li class="task-list__section">
         <h2 class="task-list__heading">Help people find your service</h2>
         <ul class="task-list__sublist">
-            <% task_list_sections[1].each do |s| %>
+            <% task_list_sections(@custom_field_sections)[1].each do |s| %>
                 <li class="task-list__item">
                     <%= render "task_list_item", s: s %>
                 </li>
@@ -48,16 +48,11 @@
     <li class="task-list__section">
         <h2 class="task-list__heading">Extra information</h2>
         <ul class="task-list__sublist">
-            <% task_list_sections[2].each do |s| %>
+            <% task_list_sections(@custom_field_sections)[2].each do |s| %>
                 <li class="task-list__item">
                     <%= render "task_list_item", s: s %>
                 </li>
             <% end %>
-             <% if @custom_field_sections.length > 0 %>
-                    <li class="task-list__item">
-                        <%= render "task_list_item", s: "Extra questions" %>
-                    </li>
-                <% end %>
         </ul>
     </li>
 

--- a/db/migrate/20240510133524_add_custom_fields_count_to_custom_field_sections.rb
+++ b/db/migrate/20240510133524_add_custom_fields_count_to_custom_field_sections.rb
@@ -1,0 +1,5 @@
+class AddCustomFieldsCountToCustomFieldSections < ActiveRecord::Migration[6.0]
+  def change
+    add_column :custom_field_sections, :custom_fields_count, :integer
+  end
+end

--- a/db/migrate/20240510133929_reset_all_custom_field_sections_cache_counters.rb
+++ b/db/migrate/20240510133929_reset_all_custom_field_sections_cache_counters.rb
@@ -1,0 +1,10 @@
+class ResetAllCustomFieldSectionsCacheCounters < ActiveRecord::Migration[6.0]
+  def up
+    CustomFieldSection.all.each do |section|
+      CustomFieldSection.reset_counters(section.id, :custom_fields)
+    end
+  end
+  def down
+    # no rollback needed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_24_230543) do
+ActiveRecord::Schema.define(version: 2024_05_10_133929) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "pg_trgm"
   enable_extension "plpgsql"
 
@@ -77,6 +76,7 @@ ActiveRecord::Schema.define(version: 2023_08_24_230543) do
     t.boolean "public"
     t.integer "sort_order"
     t.boolean "api_public"
+    t.integer "custom_fields_count"
   end
 
   create_table "custom_fields", force: :cascade do |t|
@@ -285,7 +285,6 @@ ActiveRecord::Schema.define(version: 2023_08_24_230543) do
     t.string "postcode"
     t.string "ward"
     t.string "family_centre"
-    t.string "area"
   end
 
   create_table "send_needs", force: :cascade do |t|

--- a/spec/features/community_user_managing_services_spec.rb
+++ b/spec/features/community_user_managing_services_spec.rb
@@ -4,6 +4,7 @@ feature 'Community user managing services', type: :feature do
   let!(:suitabilities) { FactoryBot.create_list :suitability, 5 }
   let!(:taxonomies) { FactoryBot.create_list :taxonomy, 5 }
 
+
   before do
     user = FactoryBot.create :user
     login_as user
@@ -15,62 +16,82 @@ feature 'Community user managing services', type: :feature do
     expect(page).to have_content("Your users")
   end
 
-  scenario 'I can add a service to the directory' do
-    click_link_or_button('Add Service, Event or Activity')
+  context 'With custom fields available to provider' do
+    let!(:custom_field_section) { FactoryBot.create :custom_field_section, public: true }
+    let!(:custom_field) { FactoryBot.create :custom_field, custom_field_section: custom_field_section }
 
-    fill_in('What is your service or activity called?', with: 'Example service')
-    fill_in('Describe your service', with: 'Example description here')
-    click_link_or_button('Continue')
+    scenario 'I can add a service to the directory' do
+      click_link_or_button('Add Service, Event or Activity')
 
-    expect(page).to have_content("List a new service")
-    expect(page).to have_content("Submission incomplete")
+      fill_in('What is your service or activity called?', with: 'Example service')
+      fill_in('Describe your service', with: 'Example description here')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Website and social media')
-    fill_in('Website', with: 'http://example.com')
-    click_link_or_button('Continue')
+      expect(page).to have_content("List a new service")
+      expect(page).to have_content("Submission incomplete")
+      expect(page).to have_content("You've completed 1 of 11 sections.")
+      expect(page).to have_content("Extra questions")
 
-    click_link_or_button('Visibility')
-    uncheck("Make this service publicly visible")
-    check("Make this service publicly visible")
-    fill_in('From', with: '01/01/2020')
-    fill_in('To', with: '01/01/2021')
-    click_link_or_button('Continue')
+      click_link_or_button('Website and social media')
+      fill_in('Website', with: 'http://example.com')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Opening times')
-    click_link_or_button('Continue')
+      click_link_or_button('Visibility')
+      uncheck("Make this service publicly visible")
+      check("Make this service publicly visible")
+      fill_in('From', with: '01/01/2020')
+      fill_in('To', with: '01/01/2021')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Fees')
-    click_link_or_button('Continue')
+      click_link_or_button('Opening times')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Locations')
-    click_link_or_button('Continue')
+      click_link_or_button('Fees')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Contacts')
-    click_link_or_button('Continue')
+      click_link_or_button('Locations')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Ages')
-    fill_in('Minimum', with: '5')
-    fill_in('Maximum', with: '10')
-    click_link_or_button('Continue')
+      click_link_or_button('Contacts')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Special educational needs and disabilities')
-    check("This service is part of the SEND local offer")
-    uncheck("This service is part of the SEND local offer")
-    click_link_or_button('Continue')
+      click_link_or_button('Ages')
+      fill_in('Minimum', with: '5')
+      fill_in('Maximum', with: '10')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Suitable for')
-    check suitabilities.first.name
-    click_link_or_button('Continue')
+      click_link_or_button('Special educational needs and disabilities')
+      check("This service is part of the SEND local offer")
+      uncheck("This service is part of the SEND local offer")
+      click_link_or_button('Continue')
 
-    click_link_or_button('Extra questions')
-    click_link_or_button('Continue')
+      click_link_or_button('Suitable for')
+      check suitabilities.first.name
+      click_link_or_button('Continue')
 
-    expect(page).to have_content("Ready to submit")
-    click_link_or_button('Finish and send')
-    expect(page).to have_content("Your service has been successfully submitted")
+      click_link_or_button('Extra questions')
+      click_link_or_button('Continue')
 
-    click_link_or_button('Return to dashboard')
-    expect(page).to have_content("Example service")
-    expect(page).to have_content("Pending")
+      expect(page).to have_content("Ready to submit")
+      click_link_or_button('Finish and send')
+      expect(page).to have_content("Your service has been successfully submitted")
+
+      click_link_or_button('Return to dashboard')
+
+      expect(page).to have_content("Example service")
+      expect(page).to have_content("Pending")
+    end
+  end
+
+  context 'With no custom fields available to provider' do
+    scenario 'I see no option for extra questions' do
+      click_link_or_button('Add Service, Event or Activity')
+      fill_in('What is your service or activity called?', with: 'Example service')
+      fill_in('Describe your service', with: 'Example description here')
+      click_link_or_button('Continue')
+
+      expect(page).to have_content("You've completed 1 of 10 sections.")
+      expect(page).to_not have_content("Extra questions")
+    end
   end
 end


### PR DESCRIPTION
If you don't have any custom field section with `Visible to community users?` checked (and if there are no fields assigned to that section) then don't show the `Extra Questions` field. 


![image](https://github.com/wearefuturegov/outpost/assets/649148/bbb4a670-19e9-48ce-b69f-51e50c1e2413)
![image](https://github.com/wearefuturegov/outpost/assets/649148/bf203420-4216-49d3-8649-48ee97c28ab9)
