### PR TITLE
Feature/mongo development updates

### DIFF
--- a/.docker/services/mongo/mongo.yml
+++ b/.docker/services/mongo/mongo.yml
@@ -1,7 +1,8 @@
 version: "3.7"
 services:
   mongo:
-    image: mongo:6
+    image: mongo:latest
+    platform: linux/arm64
     ports:
       - 27018:27017
     volumes:

--- a/.docker/services/outpost-api-service/outpost-api-service.yml
+++ b/.docker/services/outpost-api-service/outpost-api-service.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   outpost-api-service:
     image: ghcr.io/wearefuturegov/outpost-api-service:latest
-    container_name: outpost-api-service
+    platform: linux/arm64
     environment:
       NODE_ENV: development
       FORCE_SSL: false


### PR DESCRIPTION
Some small changes to the setup to match the outpost-api-service changes. 
Sets the platform for silicon macs by default, this is only relevant for development.