### PR TITLE
test - dont specify platform

### DIFF
--- a/.github/workflows/publish-dev-base.yml
+++ b/.github/workflows/publish-dev-base.yml
@@ -14,18 +14,9 @@ on:
 jobs:
   publish-dev-base:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platforms: ["linux/amd64", "linux/arm64", "linux/arm64/v8"]
     steps:
       - name: "Checkout GitHub Action"
         uses: actions/checkout@main
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: "Login to GitHub Container Registry"
         uses: docker/login-action@v3
@@ -40,7 +31,6 @@ jobs:
           context: .
           tags: ghcr.io/wearefuturegov/outpost-dev-base
           file: .docker/images/dev-base/Dockerfile
-          platforms: ${{ matrix.platforms }}
           push: true
           outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Outpost dev base image
           labels: org.opencontainers.image.source=https://github.com/wearefuturegov/outpost


### PR DESCRIPTION
remove multi platform build support for the outpost-dev-base image since its based on heroku:20 which doesn't have support for linux/arm64 