### PR TITLE
TOP-250 one off events not showing date 🤦‍♀️

### DIFF
--- a/.docker/services/outpost-api-service/outpost-api-service.yml
+++ b/.docker/services/outpost-api-service/outpost-api-service.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   outpost-api-service:
     image: ghcr.io/wearefuturegov/outpost-api-service:latest
-    platform: linux/arm64
+    platform: linux/amd64
     environment:
       NODE_ENV: development
       FORCE_SSL: false

--- a/app/models/regular_schedule.rb
+++ b/app/models/regular_schedule.rb
@@ -117,7 +117,7 @@ class RegularSchedule < ApplicationRecord
           "Every #{month}#{day} from #{dtstart.strftime("%d/%m/%Y")} at #{opens_at.strftime("%I:%M%P")} to #{closes_at.strftime("%I:%M%P")}#{ends}"
         end
       else
-        "#{dtstart.strftime('%A')} from #{opens_at.strftime("%I:%M%P")} to #{closes_at.strftime("%I:%M%P")}"
+        "#{dtstart.strftime('%A%e %B %Y')} from #{opens_at.strftime("%I:%M%P")} to #{closes_at.strftime("%I:%M%P")}"
       end
     else
       # opening time

--- a/spec/models/regular_schedule_spec.rb
+++ b/spec/models/regular_schedule_spec.rb
@@ -408,7 +408,7 @@ RSpec.describe RegularSchedule, type: :model do
       let(:dtstart) { DateTime.new(2023, 10, 4) } # Wednesday
       context 'single event time' do
         it 'should return description of the single event time' do
-          expect(regular_schedule.description).to eq("Wednesday from #{opens_at.strftime("%I:%M%P")} to #{closes_at.strftime("%I:%M%P")}")
+          expect(regular_schedule.description).to eq("#{dtstart.strftime('%A%e %B %Y')} from #{opens_at.strftime("%I:%M%P")} to #{closes_at.strftime("%I:%M%P")}")
         end
       end
 


### PR DESCRIPTION
One off event dates descriptions were showing as `Friday from 11:00am to 12:00pm` now they show as `Friday 4 October 2024 from 11:00am to 12:00pm`