### PR TITLE
Fix bug where invisible results weren't being returned

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -127,7 +127,7 @@ class Service < ApplicationRecord
     when "expired"
       where("visible_to < (?)", Date.today)
     when "invisible"
-      where("visible != true")
+      where("visible IS DISTINCT FROM TRUE")
     when "closed"
       where("temporarily_closed = true")
     else


### PR DESCRIPTION
Fixes an issue where filtering for "invisible" records incorrectly returns zero results. 

When filtering for invisible services with `visible != TRUE` we were expecting to get both false and NULL values. However, in postgres true excludes NULL values because NULL is neither TRUE nor FALSE - it is unknown. This means that queries like WHERE visible != TRUE will only return records where invisible is explicitly FALSE, unintentionally filtering out NULL.

Since we don't have false set to the default for this column the fix here is to use IS DISTINCT FROM TRUE to ensure that false and NULL values are treated the same.


