### PR TITLE
Fix for not actually already used meta label

### DIFF
--- a/app/views/admin/custom_field_sections/_fields.html.erb
+++ b/app/views/admin/custom_field_sections/_fields.html.erb
@@ -35,6 +35,7 @@
 <% if params[:action] != 'new'  %>
 
 <h2 class="page-subheading">Fields</h2>
+<p>Add fields to your section. Note that any changes made to fields are <strong>not applied retrospectively to services</strong>.</p>
 <section class="repeater">
     <ul class="repeater__panels" aria-live="polite">
         <%= f.fields_for :custom_fields do |c| %>

--- a/app/views/admin/custom_field_sections/_repeatable-fields.html.erb
+++ b/app/views/admin/custom_field_sections/_repeatable-fields.html.erb
@@ -20,10 +20,11 @@
     <%= c.text_area :hint, class: "field__input", rows: 1 %>
 </div>
 
-<% if @section.api_public %>
+<% if @section.api_public and current_user.superadmin %>
 <div class="field">
     <%= c.label :key, "Key", class: "field__label" %>
-    <p class="field__hint">This is a unique field used to refer to this field in the API</p>
+    <p class="field__hint">This is a unique field used to refer to this field in the API. <br />
+    <strong>Caution:</strong> Changing this value will result in previous records not being returned from the database.</p>
     <%= c.text_field :key, class: "field__input", data: { slugify: true } %>
 </div>
 <% end %>

--- a/app/views/admin/services/editors/_custom-fields.html.erb
+++ b/app/views/admin/services/editors/_custom-fields.html.erb
@@ -8,7 +8,7 @@
         <% end %>
 
         <% section.custom_fields.each do |field| %>
-            <% meta = s.object.meta.find_or_initialize_by(label: field.label, key: field.key) %>
+            <% meta = s.object.meta.find_or_initialize_by(label: field.label) %>
             <%= s.fields_for :meta, meta do |c| %>
                 <%= c.hidden_field :label %>
                 <%= c.hidden_field :key %>

--- a/lib/tasks/services/map_ofsted_setting_addresses_to_custom_fields.rake
+++ b/lib/tasks/services/map_ofsted_setting_addresses_to_custom_fields.rake
@@ -16,11 +16,11 @@ namespace :services do
 
     puts 'Finding services linked to Ofsted items...'
     Service.where.not(ofsted_item: nil).find_each do |service|
-      META_KEY_MAP.each do |field, key|
-        meta = service.meta.find_or_initialize_by(key: key)
+      META_KEY_MAP.each do |field, label|
+        meta = service.meta.find_or_initialize_by(label: label)
 
         if meta.value.present?
-          puts "Meta '#{key}' already exists for service ##{service.id}, skipping"
+          puts "Meta '#{label}' already exists for service ##{service.id}, skipping"
           next
         end
 


### PR DESCRIPTION
Currently when updating a service it's searching for key and label but only label is a unique field causing the update service page to indicate an error when this is not the case.

Also updated to make clear the impact of updating key on custom fields and restricted the showing of the field to super admins only. Current entries are not updated to match, this is due to the way auditing and comparison of data is done.